### PR TITLE
Adding option to group items by a data-val-group attribute 

### DIFF
--- a/packages/validate/__tests__/integration/api/index.js
+++ b/packages/validate/__tests__/integration/api/index.js
@@ -1,4 +1,5 @@
 import validate from '../../../src';
+import { GROUP_ATTRIBUTE } from '../../../src/lib/constants';
 
 describe('Validate > Integration > API > addGroup', () => {
 
@@ -104,7 +105,7 @@ describe('Validate > Integration > API > addMethod', () => {
         });
     });
 
-    it('should not add a validation method of parameters are missing', async () => {
+    it('should not add a validation method if parameters are missing', async () => {
         // expect.assertions(6);
         document.body.innerHTML = `<form class="form">
             <label id="group1-1-label" for="group1-1">group1</label>
@@ -133,6 +134,45 @@ describe('Validate > Integration > API > addMethod', () => {
         validator.addMethod(undefined, method, message);
         expect(validator.getState().groups).toEqual({
             group1: {
+                serverErrorNode: false,
+                validators: [{ type: 'required' }],
+                fields: [input],
+                valid: false
+            }
+        });
+
+    });
+
+    it('should not add a validation method if fields cannot be found', async () => {
+        // expect.assertions(6);
+        document.body.innerHTML = `<form class="form">
+            <label id="group1-1-label" for="group1-1">group1</label>
+            <input
+                id="group1-1"
+                name="group1"
+                data-val-${GROUP_ATTRIBUTE}="groupX"
+                value=""
+                required
+                type="text" />
+        </form>`;
+        // const form = document.querySelector('.form');
+        const input = document.querySelector('#group1-1');
+        const validator = validate('form')[0];
+
+        expect(validator.getState().groups).toEqual({
+            groupX: {
+                serverErrorNode: false,
+                validators: [{ type: 'required' }],
+                fields: [input],
+                valid: false
+            }
+        });
+        const method = () => false;
+        const message = 'Custom error';
+
+        validator.addMethod('neither-name-or-group-name', method, message);
+        expect(validator.getState().groups).toEqual({
+            groupX: {
                 serverErrorNode: false,
                 validators: [{ type: 'required' }],
                 fields: [input],

--- a/packages/validate/__tests__/unit/reducers.js
+++ b/packages/validate/__tests__/unit/reducers.js
@@ -1,4 +1,4 @@
-import { ACTIONS } from '../../src/lib/constants';
+import { ACTIONS, GROUP_ATTRIBUTE } from '../../src/lib/constants';
 import Reducers from '../../src/lib/reducers';
 
 //set initial state
@@ -270,6 +270,34 @@ describe('Validate > Unit > Reducers > Add validation method', () => {
             groups: {
                 group1: {
                     fields: [input],
+                    validators: [{ type: 'custom', validatorFn, message: 'This field can never be valid' }],
+                    serverErrorNode: false,
+                    valid: false
+                }
+            }
+        });
+    });
+    it('should add a validator and collect fields based on group data attribute', async () => {
+        expect.assertions(1);
+        const validatorFn = (value, fields, param) => false;
+        document.body.innerHTML = `<form class="form" method="post" action="">
+            <label for="group1">Text</label>
+            <input id="group1" name="group1" data-val-${GROUP_ATTRIBUTE}="groupX" type="text">
+        </form>`;
+        
+        //set new group name to data group attribute, not name attribute
+        const nextState = {
+            groupName: 'groupX',
+            validator: { type: 'custom', validatorFn, message: 'This field can never be valid' }
+        };
+        const state = { groups: {} };
+        //select field based on data attribute
+        const fields = [].slice.call(document.querySelectorAll(`[data-val-${GROUP_ATTRIBUTE}="groupX"]`));
+        const output = Reducers[ACTIONS.ADD_VALIDATION_METHOD](state, nextState);
+        expect(output).toEqual({
+            groups: {
+                groupX: { //data attribute group name used as group key, not name attribute
+                    fields,
                     validators: [{ type: 'custom', validatorFn, message: 'This field can never be valid' }],
                     serverErrorNode: false,
                     valid: false

--- a/packages/validate/src/lib/constants/index.js
+++ b/packages/validate/src/lib/constants/index.js
@@ -76,3 +76,5 @@ export const DOTNET_CLASSNAMES = {
     VALID: 'field-validation-valid',
     ERROR: 'error-message'
 };
+
+export const GROUP_ATTRIBUTE = "group";

--- a/packages/validate/src/lib/factory/add-method.js
+++ b/packages/validate/src/lib/factory/add-method.js
@@ -10,8 +10,7 @@ import { ACTIONS } from '../constants';
  * 
  */
 export const addMethod = Store => (groupName, method, message) => {
-    if ((groupName === undefined || method === undefined || message === undefined) || !Store.getState()[groupName] && document.getElementsByName(groupName).length === 0){
+    if((groupName === undefined || method === undefined || message === undefined) || !Store.getState()[groupName] && (document.getElementsByName(groupName).length === 0  && [].slice.call(document.querySelectorAll('[data-val-group="'+groupName+'"]')).length === 0))
         return console.warn('Custom validation method cannot be added.');
-    }
     Store.dispatch(ACTIONS.ADD_VALIDATION_METHOD, { groupName, validator: { type: 'custom', method, message } });
 };

--- a/packages/validate/src/lib/factory/add-method.js
+++ b/packages/validate/src/lib/factory/add-method.js
@@ -10,7 +10,7 @@ import { ACTIONS } from '../constants';
  * 
  */
 export const addMethod = Store => (groupName, method, message) => {
-    if((groupName === undefined || method === undefined || message === undefined) || !Store.getState()[groupName] && (document.getElementsByName(groupName).length === 0  && [].slice.call(document.querySelectorAll('[data-val-group="'+groupName+'"]')).length === 0))
+    if ((groupName === undefined || method === undefined || message === undefined) || !Store.getState()[groupName] && (document.getElementsByName(groupName).length === 0  && [].slice.call(document.querySelectorAll('[data-val-group="'+groupName+'"]')).length === 0))
         return console.warn('Custom validation method cannot be added.');
     Store.dispatch(ACTIONS.ADD_VALIDATION_METHOD, { groupName, validator: { type: 'custom', method, message } });
 };

--- a/packages/validate/src/lib/reducers/index.js
+++ b/packages/validate/src/lib/reducers/index.js
@@ -1,4 +1,4 @@
-import { ACTIONS, DOTNET_ERROR_SPAN_DATA_ATTRIBUTE, GROUP_ATTRIBUTE} from '../constants';
+import { ACTIONS, DOTNET_ERROR_SPAN_DATA_ATTRIBUTE, GROUP_ATTRIBUTE } from '../constants';
 
 export default {
     [ACTIONS.SET_INITIAL_STATE]: (state, data) => Object.assign({}, state, data),
@@ -9,7 +9,7 @@ export default {
                 valid: true
             });
             return acc;
-        }, {}) 
+        }, {})
     }),
     [ACTIONS.CLEAR_ERROR]: (state, data) => {
         const nextGroup = {};
@@ -48,7 +48,7 @@ export default {
             state.groups[data.groupName]
                 ?  { validators: [...state.groups[data.groupName].validators, data.validator] }
                 : {
-                    fields: ([].slice.call(document.querySelectorAll('[data-val-'+GROUP_ATTRIBUTE+'="'+data.groupName+'"]'))) ? [].slice.call(document.querySelectorAll('[data-val-'+GROUP_ATTRIBUTE+'="'+data.groupName+'"]')) : [].slice.call(document.getElementsByName(data.groupName)),
+                    fields: document.querySelector('[data-val-'+GROUP_ATTRIBUTE+'="'+data.groupName+'"]') ? [].slice.call(document.querySelectorAll('[data-val-'+GROUP_ATTRIBUTE+'="'+data.groupName+'"]')) : [].slice.call(document.getElementsByName(data.groupName)),
                     serverErrorNode: document.querySelector(`[${DOTNET_ERROR_SPAN_DATA_ATTRIBUTE}=${data.groupName}]`) || false,
                     valid: false,
                     validators: [data.validator],

--- a/packages/validate/src/lib/reducers/index.js
+++ b/packages/validate/src/lib/reducers/index.js
@@ -1,4 +1,4 @@
-import { ACTIONS, DOTNET_ERROR_SPAN_DATA_ATTRIBUTE } from '../constants';
+import { ACTIONS, DOTNET_ERROR_SPAN_DATA_ATTRIBUTE, GROUP_ATTRIBUTE} from '../constants';
 
 export default {
     [ACTIONS.SET_INITIAL_STATE]: (state, data) => Object.assign({}, state, data),
@@ -9,7 +9,7 @@ export default {
                 valid: true
             });
             return acc;
-        }, {})
+        }, {}) 
     }),
     [ACTIONS.CLEAR_ERROR]: (state, data) => {
         const nextGroup = {};
@@ -48,7 +48,7 @@ export default {
             state.groups[data.groupName]
                 ?  { validators: [...state.groups[data.groupName].validators, data.validator] }
                 : {
-                    fields: [].slice.call(document.getElementsByName(data.groupName)),
+                    fields: ([].slice.call(document.querySelectorAll('[data-val-'+GROUP_ATTRIBUTE+'="'+data.groupName+'"]'))) ? [].slice.call(document.querySelectorAll('[data-val-'+GROUP_ATTRIBUTE+'="'+data.groupName+'"]')) : [].slice.call(document.getElementsByName(data.groupName)),
                     serverErrorNode: document.querySelector(`[${DOTNET_ERROR_SPAN_DATA_ATTRIBUTE}=${data.groupName}]`) || false,
                     valid: false,
                     validators: [data.validator],

--- a/packages/validate/src/lib/validator/index.js
+++ b/packages/validate/src/lib/validator/index.js
@@ -171,8 +171,6 @@ export const assembleValidationGroup = (acc, input) => {
     let name = (input.getAttribute('data-val-'+GROUP_ATTRIBUTE)) ? input.getAttribute('data-val-'+GROUP_ATTRIBUTE) : input.getAttribute('name') ;
     if (!name) return console.warn('Missing data group or name attribute'), acc;
     
-    console.log(acc);
-
     return acc[name] = acc[name] ? Object.assign(acc[name], { fields: [...acc[name].fields, input] })
         : {
             valid: false,
@@ -281,7 +279,6 @@ export const getValidityState = groups => Promise.all(
 export const getGroupValidityState = group => {
     let hasError = false;
     return Promise.all(group.validators.map(validator => new Promise((resolve, reject) => {
-        console.log(validator);
         if (validator.type !== 'remote'){
             if (validate(group, validator)) resolve(true);
             else {

--- a/packages/validate/src/lib/validator/index.js
+++ b/packages/validate/src/lib/validator/index.js
@@ -10,7 +10,8 @@ import {
     DOTNET_ADAPTORS,
     DOTNET_PARAMS,
     DOTNET_ERROR_SPAN_DATA_ATTRIBUTE,
-    DOM_SELECTOR_PARAMS
+    DOM_SELECTOR_PARAMS,
+    GROUP_ATTRIBUTE
 } from '../constants';
 
 /**
@@ -167,14 +168,17 @@ export const validate = (group, validator) => validator.type === 'custom'
  * 
  */
 export const assembleValidationGroup = (acc, input) => {
-    let name = input.getAttribute('name');
-    if (!name) return console.warn('Missing name attribute'), acc;
+    let name = (input.getAttribute('data-val-'+GROUP_ATTRIBUTE)) ? input.getAttribute('data-val-'+GROUP_ATTRIBUTE) : input.getAttribute('name') ;
+    if (!name) return console.warn('Missing data group or name attribute'), acc;
+    
+    console.log(acc);
+
     return acc[name] = acc[name] ? Object.assign(acc[name], { fields: [...acc[name].fields, input] })
         : {
             valid: false,
             validators: normaliseValidators(input),
             fields: [input],
-            serverErrorNode: document.querySelector(`[${DOTNET_ERROR_SPAN_DATA_ATTRIBUTE}="${input.getAttribute('name')}"]`) || false
+            serverErrorNode: document.querySelector(`[${DOTNET_ERROR_SPAN_DATA_ATTRIBUTE}="${name}"]`) || false
         }, acc;
 };
 
@@ -277,6 +281,7 @@ export const getValidityState = groups => Promise.all(
 export const getGroupValidityState = group => {
     let hasError = false;
     return Promise.all(group.validators.map(validator => new Promise((resolve, reject) => {
+        console.log(validator);
         if (validator.type !== 'remote'){
             if (validate(group, validator)) resolve(true);
             else {


### PR DESCRIPTION
Adds the option to group validation inputs by a data attribute, rather than just by name.

A couple of recent lenus forms have used seperate number inputs for DD/MM/YYYY that the server required to have separate name attributes, however they needed to be validated together as a group with a custom function.