### PR TITLE
Clearing any existing errors when a group is removed

### DIFF
--- a/packages/validate/example/src/index.html
+++ b/packages/validate/example/src/index.html
@@ -173,54 +173,15 @@
         <input type="submit" name="onward" value="Submit">
         <input type="submit" value="Submit">
     </form> -->
+    <button class="js-add">Required last field</button>
     <form class="js-validate" action="#" autocomplete="off">
-        <div class="form-row">
-            <label class="label" for="mce-EMAIL">
-                Email address
-                <!-- <span data-valmsg-for="EMAIL" role="alert">Email is not a valid email address</span> -->
-            </label>
-            <!-- <input
-                class="input"
-                type="email"
-                id="mce-EMAIL"
-                name="EMAIL"
-                aria-invalid="true"
-                data-val="true"
-                data-val-required="Email is incomplete"
-                data-val-email="Email is not a valid email address"
-                data-val-maxlength="Email address must not exceed 254 characters"
-                data-val-maxlength-max="254"
-            /> -->
-            <input
-                class="input"
-                type="email"
-                id="mce-EMAIL"
-                name="EMAIL"
-                required
-            />
+        <div class="form-group">
+            <label for="RequiredString1">Required String</label>
+            <input class="form-control" type="text" id="RequiredString1" name="RequiredString1" value="" required />
         </div>
-        <div class="form-row">
-            <label class="label" for="VERIFY-EMAIL">Verify email address</label>
-            <!-- <input
-                class="input"
-                type="email"
-                id="VERIFY-EMAIL"
-                name="VERIFY-EMAIL"
-                data-val="true"
-                data-val-required="Verify email is incomplete"
-                data-val-email="Verify email is not a valid email address"
-                data-val-maxlength="Verify email address must not exceed 254 characters"
-                data-val-maxlength-max="254"
-                data-val-equalto="'Verify email' must match 'email'"
-                data-val-equalto-other="EMAIL"
-            /> -->
-            <input
-                class="input"
-                type="email"
-                id="VERIFY-EMAIL"
-                name="VERIFY-EMAIL"
-                required
-            />
+        <div class="form-group">
+            <label for="Later">Required later</label>
+            <input class="form-control" type="text" id="Later" name="Later" value="" />
         </div>
         <input type="submit" value="Submit">
     </form>

--- a/packages/validate/example/src/js/index.js
+++ b/packages/validate/example/src/js/index.js
@@ -2,14 +2,14 @@ import validate from '../../../src';
 {
     const validator = validate('form');
 
-    // const later = document.getElementById('Later');
-    // document.querySelector('.js-add').addEventListener('click', e => {
-    //     if (later.hasAttribute('required')) {
-    //         later.removeAttribute('required');
-    //         validator[0].removeGroup(later.getAttribute('name'));
-    //     } else {
-    //         later.setAttribute('required', 'required');
-    //         validator[0].addGroup([later]);
-    //     }
-    // });
+    const later = document.getElementById('Later');
+    document.querySelector('.js-add').addEventListener('click', e => {
+        if (later.hasAttribute('required')) {
+            later.removeAttribute('required');
+            validator[0].removeGroup(later.getAttribute('name'));
+        } else {
+            later.setAttribute('required', 'required');
+            validator[0].addGroup([later]);
+        }
+    });
 };

--- a/packages/validate/src/lib/dom/index.js
+++ b/packages/validate/src/lib/dom/index.js
@@ -51,19 +51,26 @@ export const createErrorTextNode = (group, msg) => {
  * 
  */
 export const clearError = groupName => state => {
-    if (state.groups[groupName].serverErrorNode) {
-        state.groups[groupName].serverErrorNode.innerHTML = '';
-        state.groups[groupName].serverErrorNode.classList.remove(DOTNET_CLASSNAMES.ERROR);
-        state.groups[groupName].serverErrorNode.classList.add(DOTNET_CLASSNAMES.VALID);
-        state.groups[groupName].serverErrorNode.removeAttribute('role');
-    } else {
+    if(state.groups[groupName]) {
+        if (state.groups[groupName].serverErrorNode) {
+            state.groups[groupName].serverErrorNode.innerHTML = '';
+            state.groups[groupName].serverErrorNode.classList.remove(DOTNET_CLASSNAMES.ERROR);
+            state.groups[groupName].serverErrorNode.classList.add(DOTNET_CLASSNAMES.VALID);
+            state.groups[groupName].serverErrorNode.removeAttribute('role');
+        }
+
+        if(state.groups[groupName].fields) {
+            state.groups[groupName].fields.forEach(field => {
+                field.parentNode.classList.remove('is--invalid');
+                field.removeAttribute('aria-invalid');
+            });
+        }
+    } 
+        
+    if (state.errors[groupName]) {
         state.errors[groupName].parentNode.removeChild(state.errors[groupName]);
+        delete state.errors[groupName];//shouldn't be doing this here...
     }
-    state.groups[groupName].fields.forEach(field => {
-        field.parentNode.classList.remove('is--invalid');
-        field.removeAttribute('aria-invalid');
-    });
-    delete state.errors[groupName];//shouldn't be doing this here...
 };
 
 /**

--- a/packages/validate/src/lib/dom/index.js
+++ b/packages/validate/src/lib/dom/index.js
@@ -57,6 +57,8 @@ export const clearError = groupName => state => {
             state.groups[groupName].serverErrorNode.classList.remove(DOTNET_CLASSNAMES.ERROR);
             state.groups[groupName].serverErrorNode.classList.add(DOTNET_CLASSNAMES.VALID);
             state.groups[groupName].serverErrorNode.removeAttribute('role');
+        } else {
+            state.errors[groupName].parentNode.removeChild(state.errors[groupName]);
         }
 
         if(state.groups[groupName].fields) {
@@ -68,7 +70,6 @@ export const clearError = groupName => state => {
     } 
         
     if (state.errors[groupName]) {
-        state.errors[groupName].parentNode.removeChild(state.errors[groupName]);
         delete state.errors[groupName];//shouldn't be doing this here...
     }
 };

--- a/packages/validate/src/lib/dom/index.js
+++ b/packages/validate/src/lib/dom/index.js
@@ -51,27 +51,19 @@ export const createErrorTextNode = (group, msg) => {
  * 
  */
 export const clearError = groupName => state => {
-    if(state.groups[groupName]) {
-        if (state.groups[groupName].serverErrorNode) {
-            state.groups[groupName].serverErrorNode.innerHTML = '';
-            state.groups[groupName].serverErrorNode.classList.remove(DOTNET_CLASSNAMES.ERROR);
-            state.groups[groupName].serverErrorNode.classList.add(DOTNET_CLASSNAMES.VALID);
-            state.groups[groupName].serverErrorNode.removeAttribute('role');
-        } else {
-            state.errors[groupName].parentNode.removeChild(state.errors[groupName]);
-        }
-
-        if(state.groups[groupName].fields) {
-            state.groups[groupName].fields.forEach(field => {
-                field.parentNode.classList.remove('is--invalid');
-                field.removeAttribute('aria-invalid');
-            });
-        }
-    } 
-        
-    if (state.errors[groupName]) {
-        delete state.errors[groupName];//shouldn't be doing this here...
+    if (state.groups[groupName].serverErrorNode) {
+        state.groups[groupName].serverErrorNode.innerHTML = '';
+        state.groups[groupName].serverErrorNode.classList.remove(DOTNET_CLASSNAMES.ERROR);
+        state.groups[groupName].serverErrorNode.classList.add(DOTNET_CLASSNAMES.VALID);
+        state.groups[groupName].serverErrorNode.removeAttribute('role');
+    } else {
+        state.errors[groupName].parentNode.removeChild(state.errors[groupName]);
     }
+    state.groups[groupName].fields.forEach(field => {
+        field.parentNode.classList.remove('is--invalid');
+        field.removeAttribute('aria-invalid');
+    });
+    delete state.errors[groupName];//shouldn't be doing this here...
 };
 
 /**

--- a/packages/validate/src/lib/factory/group.js
+++ b/packages/validate/src/lib/factory/group.js
@@ -1,4 +1,5 @@
 import { removeUnvalidatableGroups, assembleValidationGroup } from '../validator';
+import { clearError } from '../dom';
 import { ACTIONS } from '../constants';
 
 /**
@@ -23,5 +24,5 @@ export const addGroup = Store => nodes => {
  * 
  */
 export const removeGroup = Store => groupName => {
-    Store.dispatch(ACTIONS.REMOVE_GROUP, groupName);
+    Store.dispatch(ACTIONS.REMOVE_GROUP, groupName, [ clearError(groupName) ]);
 };

--- a/packages/validate/src/lib/factory/group.js
+++ b/packages/validate/src/lib/factory/group.js
@@ -24,5 +24,6 @@ export const addGroup = Store => nodes => {
  * 
  */
 export const removeGroup = Store => groupName => {
-    Store.dispatch(ACTIONS.REMOVE_GROUP, groupName, [ clearError(groupName) ]);
+    clearError(groupName)(Store.getState());
+    Store.dispatch(ACTIONS.REMOVE_GROUP, groupName);
 };

--- a/packages/validate/src/lib/factory/group.js
+++ b/packages/validate/src/lib/factory/group.js
@@ -24,6 +24,7 @@ export const addGroup = Store => nodes => {
  * 
  */
 export const removeGroup = Store => groupName => {
-    clearError(groupName)(Store.getState());
+    const state = Store.getState();
+    if (state.errors[groupName]) clearError(groupName)(state);
     Store.dispatch(ACTIONS.REMOVE_GROUP, groupName);
 };


### PR DESCRIPTION
Hi Mick,

When I was using the add/remove groups functionality I was finding that if there were any groups that were removed from validation that had existing errors on them, it was causing the script to error.  

This is adding the clearError function onto the REMOVE_GROUP action, and adding some conditions to the clearError to check for the existence of a group (in case it has been removed by the action).

Let me know if there's a neater way to do this!  