### PR TITLE
Cookie banner > separate initialising listeners from banner rendering

### DIFF
--- a/packages/cookie-banner/src/lib/factory.js
+++ b/packages/cookie-banner/src/lib/factory.js
@@ -1,5 +1,5 @@
 import { cookiesEnabled, extractFromCookie, noop } from './utils';
-import { initBanner, initForm } from './ui';
+import { initBanner, initForm, initBannerListeners } from './ui';
 import { necessary, apply } from './consent';
 import { createStore } from './store';
 import { initialState } from './reducers';
@@ -14,7 +14,7 @@ export default settings => {
     //for sites that are saving the cookie consent in a different shape, i.e. without cid and consent properties
     //and for sites with cookies that are not base64 encoded
     const [ hasCookie, cid, consent ] = extractFromCookie(settings);
-     
+    
     Store.update(
         initialState,
         {
@@ -25,8 +25,9 @@ export default settings => {
         [
             necessary,
             apply(Store),
-            hasCookie ? noop : initBanner(Store),
-            initForm(Store)
+            hasCookie ? noop : initBanner,
+            initForm(Store),
+            initBannerListeners(Store)
         ]
     );
 

--- a/packages/cookie-banner/src/lib/ui.js
+++ b/packages/cookie-banner/src/lib/ui.js
@@ -4,14 +4,19 @@ import { apply } from './consent';
 import { updateConsent } from './reducers';
 import { measure, composeMeasurementConsent } from './measurement';
 
-export const initBanner = Store => state => {
+export const initBanner = state => {
     if (state.settings.hideBannerOnFormPage && document.querySelector(`.${state.settings.classNames.formContainer}`)) return;
     document.body.firstElementChild.insertAdjacentHTML('beforebegin', state.settings.bannerTemplate(state.settings));
     
     //track banner display
     if (state.settings.tid) measure(state, MEASUREMENTS.BANNER_DISPLAY);
+};
 
+
+export const initBannerListeners = Store => state => {
     const banner = document.querySelector(`.${state.settings.classNames.banner}`);
+    if (!banner) return;
+    
     const acceptBtns = [].slice.call(document.querySelectorAll(`.${state.settings.classNames.acceptBtn}`));
     const optionsBtn = document.querySelector(`.${state.settings.classNames.optionsBtn}`);
 


### PR DESCRIPTION
Separate banner listeners from banner rendering to support submit and option buttons being in the consent form