### PR TITLE
Issues/132 modal

### DIFF
--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -10,7 +10,7 @@ Create a modal dialog and button(s) to toggle in HTML
 ```
 <button class="js-modal-toggle">Open modal</button>
 <div id="modal-1" class="js-modal modal" data-modal-toggle="js-modal-toggle" hidden>
-    <div class="modal__inner" role="dialog" aria-modal="true" aria-labelledby="modal-label">
+    <div class="modal__inner" role="dialog" aria-labelledby="modal-label">
         <h2 id="modal-label">Modal title</h2>
         ...
         <button class="modal__close-btn js-modal-toggle" aria-label="close">
@@ -33,6 +33,15 @@ Inititialise the module
 import modal from '@stormid/modal';
 
 const [ instance ] = modal('.js-modal');
+```
+
+CSS
+The className 'is--modal' added to the document.body when the modal is open. This can be used to prevent the body from scrolling
+
+```
+.is--modal {
+    overflow: hidden;
+}
 ```
 
 ## Options

--- a/packages/modal/__tests__/integrations.js
+++ b/packages/modal/__tests__/integrations.js
@@ -72,11 +72,13 @@ describe(`Modal > Mouse events`, () => {
         expect(ModalSet[0].getState().node.hasAttribute('hidden')).toEqual(false);
         expect(document.body.firstElementChild).toEqual(ModalSet[0].getState().node);
         Array.from(document.querySelectorAll('.container')).forEach(container => expect(container.getAttribute('aria-hidden')).toEqual('true'));
+        expect(document.body.classList.contains('is--modal')).toEqual(true)
         
         ModalSet[0].getState().toggles[0].click();
         expect(Array.from(ModalSet[0].getState().node.classList)).not.toContain(defaults.onClassName);
         expect(ModalSet[0].getState().node.hasAttribute('hidden')).toEqual(true);
         Array.from(document.querySelectorAll('.container')).forEach(container => expect(container.hasAttribute('aria-hidden')).toEqual(false));
+        expect(document.body.classList.contains('is--modal')).toEqual(false)
         
     });
 
@@ -90,8 +92,10 @@ describe(`Modal > Keyboard events`, () => {
         const space = new window.KeyboardEvent('keydown', { keyCode: 32, bubbles: true });
         ModalSet[0].getState().toggles[0].dispatchEvent(space);
         expect(Array.from(ModalSet[0].getState().node.classList)).toContain(defaults.onClassName);
+        expect(document.body.classList.contains('is--modal')).toEqual(true)
         ModalSet[0].getState().toggles[0].dispatchEvent(space);
         expect(Array.from(ModalSet[0].getState().node.classList)).not.toContain(defaults.onClassName);
+        expect(document.body.classList.contains('is--modal')).toEqual(false)
     });
     
     it('should attach the keydown eventListener to DOMElement to toggle documentElement className for enter key', () => {

--- a/packages/modal/__tests__/integrations.js
+++ b/packages/modal/__tests__/integrations.js
@@ -72,13 +72,13 @@ describe(`Modal > Mouse events`, () => {
         expect(ModalSet[0].getState().node.hasAttribute('hidden')).toEqual(false);
         expect(document.body.firstElementChild).toEqual(ModalSet[0].getState().node);
         Array.from(document.querySelectorAll('.container')).forEach(container => expect(container.getAttribute('aria-hidden')).toEqual('true'));
-        expect(document.body.classList.contains('is--modal')).toEqual(true)
+        expect(document.documentElement.classList.contains('is--modal')).toEqual(true)
         
         ModalSet[0].getState().toggles[0].click();
         expect(Array.from(ModalSet[0].getState().node.classList)).not.toContain(defaults.onClassName);
         expect(ModalSet[0].getState().node.hasAttribute('hidden')).toEqual(true);
         Array.from(document.querySelectorAll('.container')).forEach(container => expect(container.hasAttribute('aria-hidden')).toEqual(false));
-        expect(document.body.classList.contains('is--modal')).toEqual(false)
+        expect(document.documentElement.classList.contains('is--modal')).toEqual(false)
         
     });
 
@@ -92,10 +92,10 @@ describe(`Modal > Keyboard events`, () => {
         const space = new window.KeyboardEvent('keydown', { keyCode: 32, bubbles: true });
         ModalSet[0].getState().toggles[0].dispatchEvent(space);
         expect(Array.from(ModalSet[0].getState().node.classList)).toContain(defaults.onClassName);
-        expect(document.body.classList.contains('is--modal')).toEqual(true)
+        expect(document.documentElement.classList.contains('is--modal')).toEqual(true)
         ModalSet[0].getState().toggles[0].dispatchEvent(space);
         expect(Array.from(ModalSet[0].getState().node.classList)).not.toContain(defaults.onClassName);
-        expect(document.body.classList.contains('is--modal')).toEqual(false)
+        expect(document.documentElement.classList.contains('is--modal')).toEqual(false)
     });
     
     it('should attach the keydown eventListener to DOMElement to toggle documentElement className for enter key', () => {

--- a/packages/modal/example/src/index.html
+++ b/packages/modal/example/src/index.html
@@ -90,6 +90,9 @@
             white-space: nowrap;
             width: 1px;
         }
+        .is--modal {
+            overflow: hidden;
+        }
     </style>
   </head>
   <body>

--- a/packages/modal/example/src/index.html
+++ b/packages/modal/example/src/index.html
@@ -93,9 +93,8 @@
     </style>
   </head>
   <body>
-    <div></div>
-    <div></div>
-    <div></div>
+    <div style="height: 300px;background-color: #ddd"></div>
+    <div style="height: 200px;background-color: #666"></div>
     <div>
         <button class="js-modal-toggle">Open modal</button>
         <div id="modal-1" class="js-modal modal" data-modal-toggle="js-modal-toggle" hidden>
@@ -113,6 +112,7 @@
             </div>
         </div>
     </div>
+    <div style="height: 1000px;background-color: #aaa"></div>
     <div></div>
     <div></div>
   </body>

--- a/packages/modal/src/lib/dom.js
+++ b/packages/modal/src/lib/dom.js
@@ -88,6 +88,7 @@ const open = state => {
     const focusFn = () => state.focusableChildren.length > 0 && state.focusableChildren[0].focus();
     if (state.settings.delay) window.setTimeout(focusFn, state.settings.delay);
     else focusFn();
+    document.body.style.setProperty('overflow', 'hidden');
 };
 
 /* 
@@ -96,6 +97,7 @@ const open = state => {
 const close = state => {
     document.removeEventListener('keydown', state.keyListener);
     toggle(state);
+    document.body.style.removeProperty('overflow');
     state.lastFocused.focus();
 };
 

--- a/packages/modal/src/lib/dom.js
+++ b/packages/modal/src/lib/dom.js
@@ -74,6 +74,7 @@ const toggle = state => {
     const children = [].slice.call(document.querySelectorAll('body > *'));
     children.forEach(child => child !== state.node && child[state.isOpen ? 'setAttribute' : 'removeAttribute']('aria-hidden', 'true'));
     state.node.classList.toggle(state.settings.onClassName);
+    document.body.classList.toggle('is--modal');
 };
 
 /* 
@@ -88,7 +89,6 @@ const open = state => {
     const focusFn = () => state.focusableChildren.length > 0 && state.focusableChildren[0].focus();
     if (state.settings.delay) window.setTimeout(focusFn, state.settings.delay);
     else focusFn();
-    document.body.style.setProperty('overflow', 'hidden');
 };
 
 /* 
@@ -97,7 +97,6 @@ const open = state => {
 const close = state => {
     document.removeEventListener('keydown', state.keyListener);
     toggle(state);
-    document.body.style.removeProperty('overflow');
     state.lastFocused.focus();
 };
 

--- a/packages/modal/src/lib/dom.js
+++ b/packages/modal/src/lib/dom.js
@@ -74,7 +74,7 @@ const toggle = state => {
     const children = [].slice.call(document.querySelectorAll('body > *'));
     children.forEach(child => child !== state.node && child[state.isOpen ? 'setAttribute' : 'removeAttribute']('aria-hidden', 'true'));
     state.node.classList.toggle(state.settings.onClassName);
-    document.body.classList.toggle('is--modal');
+    document.documentElement.classList.toggle('is--modal');
 };
 
 /* 


### PR DESCRIPTION
This PR addresses #132 but not in exactly the same way as described in the issue.

This is a very basic unobtrusive implementation adding a className to the document.documentElement so a developer can add CSS to prevent scrolling in the way best befitting the project.

The README documents the simplest implementation (.is--modal { overflow: hidden }). We could add the same implementation to the modal patterns in the ui-patterns project.

This solution is the least prescriptive/intrusive allowing alternative implementations - adding inline styles to set overflow, setting height of 100vh and caching window.scrollY, etc - still to be supported via the callback option.