### PR TITLE
Add custom events to toggle

### DIFF
--- a/docs/modal.html
+++ b/docs/modal.html
@@ -201,7 +201,7 @@
 <p>Create a modal dialog and button(s) to toggle in HTML</p>
 <pre><code>&lt;button class=&quot;js-modal-toggle&quot;&gt;Open modal&lt;/button&gt;
 &lt;div id=&quot;modal-1&quot; class=&quot;js-modal modal&quot; data-modal-toggle=&quot;js-modal-toggle&quot; hidden&gt;
-    &lt;div class=&quot;modal__inner&quot; role=&quot;dialog&quot; aria-modal=&quot;true&quot; aria-labelledby=&quot;modal-label&quot;&gt;
+    &lt;div class=&quot;modal__inner&quot; role=&quot;dialog&quot; aria-labelledby=&quot;modal-label&quot;&gt;
         &lt;h2 id=&quot;modal-label&quot;&gt;Modal title&lt;/h2&gt;
         ...
         &lt;button class=&quot;modal__close-btn js-modal-toggle&quot; aria-label=&quot;close&quot;&gt;
@@ -220,6 +220,12 @@
 <pre><code>import modal from '@stormid/modal';
 
 const [ instance ] = modal('.js-modal');
+</code></pre>
+<p>CSS
+The className ‘is–modal’ added to the document.body when the modal is open. This can be used to prevent the body from scrolling</p>
+<pre><code>.is--modal {
+    overflow: hidden;
+}
 </code></pre>
 <h2 id="options">Options</h2>
 <pre><code>{

--- a/packages/toggle/__tests__/integrations.js
+++ b/packages/toggle/__tests__/integrations.js
@@ -1,4 +1,5 @@
 import toggle from '../src';
+import { EVENTS } from '../src/lib/constants';
 
 let Toggles, TogglesLocal;
 
@@ -206,4 +207,46 @@ describe('Toggle > lifecycle > prehook', () => {
     });
     
     
+});
+
+describe('Toggle > events', () => {
+
+    it('should dispatch an custom event when opening and closing with a reference to the instance getState', () => {
+        
+        document.body.innerHTML = `<button class="js-toggle__events-btn">Test toggle</button>
+        <div id="target--events" class="js-toggle__events" data-toggle="js-toggle__events-btn"></div>`;
+        const instance = toggle('.js-toggle__events')[0];
+        const node = document.getElementById('target--events');
+        const button = document.querySelector('.js-toggle__events-btn');
+
+        const listener = jest.fn();
+        node.addEventListener(EVENTS.OPEN, listener); 
+        node.addEventListener(EVENTS.OPEN, e => {
+            expect(e.detail.getState).toBeDefined();
+            expect(e.detail.getState().node).toEqual(node);
+            expect(e.detail.getState().isOpen).toEqual(true);
+        });
+        node.addEventListener(EVENTS.CLOSE, listener); 
+        node.addEventListener(EVENTS.CLOSE, e => {
+            expect(e.detail.getState).toBeDefined();
+            expect(e.detail.getState().node).toEqual(node);
+            expect(e.detail.getState().isOpen).toEqual(false);
+        });
+
+        //start closed
+        expect(instance.getState().isOpen).toEqual(false);
+
+        //open
+        button.click();
+        expect(instance.getState().isOpen).toEqual(true);
+        expect(listener).toHaveBeenCalled();
+
+        //close
+        button.click();
+        expect(instance.getState().isOpen).toEqual(false);
+        expect(listener).toHaveBeenCalled();
+
+
+    });
+
 });

--- a/packages/toggle/__tests__/unit/broadcast.js
+++ b/packages/toggle/__tests__/unit/broadcast.js
@@ -1,0 +1,31 @@
+import { broadcast } from '../../src/lib/dom';
+import { createStore } from '../../src/lib/store';
+import defaults from '../../src/lib/defaults';
+import { EVENTS } from '../../src/lib/constants';
+
+describe(`Toggle > broadcast`, () => {
+
+    it('should dispatch a bubbling custom event with a detail Object with a reference to Store.getState', async () => {
+        document.body.innerHTML = `<div id="target"></div>`;
+        const Store = createStore();
+        const node = document.getElementById('target');
+        const openState = {
+            node,
+            isOpen: true,
+            settings: defaults
+        };
+        Store.dispatch(openState);
+        const listener = jest.fn();
+        const delegatedlistener = jest.fn();
+        node.addEventListener(EVENTS.OPEN, listener);
+        document.addEventListener(EVENTS.OPEN, delegatedlistener);
+        node.addEventListener(EVENTS.OPEN, e => {
+            expect(e.detail).toEqual({ getState: Store.getState });
+        });
+
+        broadcast(Store)(openState);
+        expect(listener).toHaveBeenCalled();
+        expect(delegatedlistener).toHaveBeenCalled();
+    });
+
+});

--- a/packages/toggle/example/src/js/index.js
+++ b/packages/toggle/example/src/js/index.js
@@ -9,4 +9,8 @@ window.addEventListener('DOMContentLoaded', () => {
     window.__t2__ = toggle('.js-toggle__local', {
         closeOnBlur: true
     });
+
+    document.addEventListener('Toggle.On', e => {
+        console.log(e);
+    });
 });

--- a/packages/toggle/example/src/js/index.js
+++ b/packages/toggle/example/src/js/index.js
@@ -10,7 +10,7 @@ window.addEventListener('DOMContentLoaded', () => {
         closeOnBlur: true
     });
 
-    document.addEventListener('Toggle.On', e => {
-        console.log(e);
+    document.addEventListener('Toggle.Open', e => {
+        console.log(e.detail.getState());
     });
 });

--- a/packages/toggle/src/lib/constants.js
+++ b/packages/toggle/src/lib/constants.js
@@ -9,6 +9,6 @@ export const TRIGGER_KEYCODES = [13, 32];
 export const FOCUSABLE_ELEMENTS = ['a[href]', 'area[href]', 'input:not([disabled])', 'select:not([disabled])', 'textarea:not([disabled])', 'button:not([disabled])', 'iframe', 'object', 'embed', '[contenteditable]', '[tabindex]:not([tabindex="-1"])'];
 
 export const EVENTS = {
-    ON: 'Toggle.On',
-    OFF: 'Toggle.Off'
+    OPEN: 'Toggle.Open',
+    CLOSE: 'Toggle.Close'
 };

--- a/packages/toggle/src/lib/constants.js
+++ b/packages/toggle/src/lib/constants.js
@@ -9,6 +9,6 @@ export const TRIGGER_KEYCODES = [13, 32];
 export const FOCUSABLE_ELEMENTS = ['a[href]', 'area[href]', 'input:not([disabled])', 'select:not([disabled])', 'textarea:not([disabled])', 'button:not([disabled])', 'iframe', 'object', 'embed', '[contenteditable]', '[tabindex]:not([tabindex="-1"])'];
 
 export const EVENTS = {
-    OPEN: 'Toggle.Open',
-    CLOSE: 'Toggle.Close'
+    OPEN: 'toggle.open',
+    CLOSE: 'toggle.close'
 };

--- a/packages/toggle/src/lib/constants.js
+++ b/packages/toggle/src/lib/constants.js
@@ -7,3 +7,8 @@ export const TRIGGER_KEYCODES = [13, 32];
 
 //Array of focusable child elements
 export const FOCUSABLE_ELEMENTS = ['a[href]', 'area[href]', 'input:not([disabled])', 'select:not([disabled])', 'textarea:not([disabled])', 'button:not([disabled])', 'iframe', 'object', 'embed', '[contenteditable]', '[tabindex]:not([tabindex="-1"])'];
+
+export const EVENTS = {
+    ON: 'Toggle.On',
+    OFF: 'Toggle.Off'
+};

--- a/packages/toggle/src/lib/dom.js
+++ b/packages/toggle/src/lib/dom.js
@@ -195,7 +195,7 @@ export const getStateFromDOM = (node, settings) => {
 };
 
 export const broadcast = Store => state => {
-    const event = new CustomEvent(EVENTS[state.isOpen ? 'ON' : 'OFF'], {
+    const event = new CustomEvent(EVENTS[state.isOpen ? 'OPEN' : 'CLOSE'], {
         detail: {
             getState: Store.getState
         }

--- a/packages/toggle/src/lib/dom.js
+++ b/packages/toggle/src/lib/dom.js
@@ -1,4 +1,4 @@
-import { FOCUSABLE_ELEMENTS, TRIGGER_EVENTS, TRIGGER_KEYCODES } from './constants';
+import { FOCUSABLE_ELEMENTS, TRIGGER_EVENTS, TRIGGER_KEYCODES, EVENTS } from './constants';
 
 /*
  * Sets aria attributes and adds eventListener on each toggle button
@@ -32,7 +32,7 @@ export const initUI = Store => () => {
 export const toggle = Store => () => {
     Store.dispatch({
         isOpen: !Store.getState().isOpen },
-    [toggleAttributes, manageFocus(Store), closeProxy(Store)]
+    [toggleAttributes, manageFocus(Store), closeProxy(Store), broadcast(Store)]
     );
 };
 
@@ -192,4 +192,13 @@ export const getStateFromDOM = (node, settings) => {
         statusClass,
         shouldStartOpen: settings.startOpen || classTarget.classList.contains(statusClass)
     };
+};
+
+export const broadcast = Store => state => {
+    const event = new CustomEvent(EVENTS[state.isOpen ? 'ON' : 'OFF'], {
+        detail: {
+            getState: Store.getState
+        }
+    });
+    document.dispatchEvent(event);
 };

--- a/packages/toggle/src/lib/dom.js
+++ b/packages/toggle/src/lib/dom.js
@@ -196,9 +196,10 @@ export const getStateFromDOM = (node, settings) => {
 
 export const broadcast = Store => state => {
     const event = new CustomEvent(EVENTS[state.isOpen ? 'OPEN' : 'CLOSE'], {
+        bubbles: true,
         detail: {
             getState: Store.getState
         }
     });
-    document.dispatchEvent(event);
+    state.node.dispatchEvent(event);
 };


### PR DESCRIPTION
Addresses #155 

- adds custom events for toggle open and toggle close
- event is dispatched on node (the same element that the toggle is initialised on)
- event is set to bubble so listener can be added to node and/or delegated
- events named 'toggle.open' and 'toggle.close', rationale:
  - scope event names with component type so events can be extended to other component types without clashes
  - dots in event names are cooler than hyphens or underscores