### PR TITLE
Trim value from input when acquiring value for validation

### DIFF
--- a/packages/validate/__tests__/integration/validator/required.js
+++ b/packages/validate/__tests__/integration/validator/required.js
@@ -36,6 +36,19 @@ describe('Validate > Integration > validator > required', () => {
         expect(validate(group, group.validators[0])).toEqual(false);
     });
 
+    it('should return the validityState false for HTML5 required validator with no value other than whitespace', async () => {
+        expect.assertions(1);
+        document.body.innerHTML = `<input
+			id="group1"
+            name="group1"
+            required
+            value="     "
+			type="text">`;
+        const input = document.querySelector('#group1');
+        const group = assembleValidationGroup({}, input).group1;
+        expect(validate(group, group.validators[0])).toEqual(false);
+    });
+
     it('should return the validityState true for HTML5 required validator with a value', async () => {
         expect.assertions(1);
         document.body.innerHTML = `<input
@@ -57,6 +70,20 @@ describe('Validate > Integration > validator > required', () => {
             data-val="true"
             data-val-required="This field is required"
             value=""
+			type="text">`;
+        const input = document.querySelector('#group1');
+        const group = assembleValidationGroup({}, input).group1;
+        expect(validate(group, group.validators[0])).toEqual(false);
+    });
+
+    it('should return the validityState false for data-val required validator with no value but whitespace', async () => {
+        expect.assertions(1);
+        document.body.innerHTML = `<input
+			id="group1"
+            name="group1"
+            data-val="true"
+            data-val-required="This field is required"
+            value="    "
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;

--- a/packages/validate/__tests__/unit/validator/utils.js
+++ b/packages/validate/__tests__/unit/validator/utils.js
@@ -210,6 +210,14 @@ describe('Validate > Unit > Utils > groupValueReducer', () => {
         const field = document.querySelector('#field');
         expect(groupValueReducer('', field)).toEqual('Test value');
     });
+    it('should trim String value given an input with a value whitespace', async () => {
+        expect.assertions(1);
+        document.body.innerHTML = `<form>
+            <input name="field" id="field" value="   Test value   " />
+        </form>`;
+        const field = document.querySelector('#field');
+        expect(groupValueReducer('', field)).toEqual('Test value');
+    });
     it('should return an empty String given an input without a value and an initial empty string', async () => {
         expect.assertions(1);
         document.body.innerHTML = `<form>

--- a/packages/validate/src/lib/validator/utils.js
+++ b/packages/validate/src/lib/validator/utils.js
@@ -29,8 +29,8 @@ export const hasValue = input => (input.value !== undefined && input.value !== n
 export const groupValueReducer = (acc, input) => {
     if (!isCheckable(input) && !isHidden(input) && hasValue(input)) acc = input.value.trim();
     if (isCheckable(input) && input.checked) {
-        if (Array.isArray(acc)) acc.push(input.value);
-        else acc = [input.value];
+        if (Array.isArray(acc)) acc.push(input.value.trim());
+        else acc = [input.value.trim()];
     }
     return acc;
 };

--- a/packages/validate/src/lib/validator/utils.js
+++ b/packages/validate/src/lib/validator/utils.js
@@ -27,7 +27,7 @@ export const groupIsDisabled = fields => fields.reduce((acc, field) => {
 export const hasValue = input => (input.value !== undefined && input.value !== null && input.value.length > 0);
 
 export const groupValueReducer = (acc, input) => {
-    if (!isCheckable(input) && !isHidden(input) && hasValue(input)) acc = input.value;
+    if (!isCheckable(input) && !isHidden(input) && hasValue(input)) acc = input.value.trim();
     if (isCheckable(input) && input.checked) {
         if (Array.isArray(acc)) acc.push(input.value);
         else acc = [input.value];


### PR DESCRIPTION
Fixes #167 

- trims value when retrieving it from a group prior to validation
- adds tests 