### PR TITLE
Validate > create validation group by passing array of fields

### DIFF
--- a/packages/validate/README.md
+++ b/packages/validate/README.md
@@ -34,22 +34,37 @@ This library supports HTML5 attribute constraints and the data-val attributes ge
 
 Multiple validators can be used on a single field. Custom validators can be added via the [addMethod](#addmethod) API.
 
-- [Required](#required)
-- [Email](#email)
-- [Url](#url)
-- [Pattern/Regex](#patternregex)
-- [Digits](#digits)
-- [Number](#number)
-- [Min](#min)
-- [Max](#max)
-- [Range](#range)
-- [Length](#length)
-- [Stringlength](#stringlength)
-- [Maxlength](#maxlength)
-- [Minlength](#minlength)
-- [DateISO](#dateiso)
-- [Equalto](#equalto)
-- [Remote](#remote)
+- [Validate](#validate)
+  - [Contents](#contents)
+  - [Usage](#usage)
+  - [Validators](#validators)
+    - [Required](#required)
+    - [Email](#email)
+    - [Url](#url)
+    - [Pattern/Regex](#patternregex)
+    - [Digits](#digits)
+    - [Number](#number)
+    - [Min](#min)
+    - [Max](#max)
+    - [Range](#range)
+    - [Length](#length)
+    - [Stringlength](#stringlength)
+    - [Maxlength](#maxlength)
+    - [Minlength](#minlength)
+    - [DateISO](#dateiso)
+    - [Equalto](#equalto)
+    - [Remote](#remote)
+  - [Errors](#errors)
+    - [Error message container](#error-message-container)
+    - [Error messages](#error-messages)
+  - [Options](#options)
+  - [API](#api)
+    - [addMethod](#addmethod)
+    - [validate](#validate-1)
+    - [addGroup](#addgroup)
+    - [removeGroup](#removegroup)
+  - [Tests](#tests)
+  - [License](#license)
 
 ---
 
@@ -327,12 +342,13 @@ Add a custom validation method to a group:
 const [ validator ] = validate('.my-form');
 
 validator.addMethod(
-    'MyFieldName', //input/input group name
+    'MyFieldName', //input/input group name/or validation group name if passing an array of fields
     (value, fields) => { //validation method
         //value is the value of the whole group of fields (grouped under the name attribute)
         return value === 'test'; //must return boolean
     },
-    'Value must equal "test"' //error message on validation failure
+    'Value must equal "test"', //error message on validation failure
+    fields // an optional array of inputs, if this isn't present the input/groupName is used as a name (or data-group) attribute selector
 );
 ```
 

--- a/packages/validate/__tests__/integration/api/index.js
+++ b/packages/validate/__tests__/integration/api/index.js
@@ -204,4 +204,46 @@ describe('Validate > Integration > API > addMethod', () => {
 
     });
 
+    it('Should add a validation method when provided an array of fields and a new group name', () => {
+        document.body.innerHTML = `<form class="form">
+            <label id="group1-1-label" for="group1-1">group1</label>
+            <input
+                id="group1-1"
+                name="group1"
+                value=""
+                required
+                type="text" />
+        </form>`;
+        // const form = document.querySelector('.form');
+        const input = document.querySelector('#group1-1');
+        const validator = validate('form')[0];
+
+        expect(validator.getState().groups).toEqual({
+            group1: {
+                serverErrorNode: false,
+                validators: [{ type: 'required' }],
+                fields: [input],
+                valid: false
+            }
+        });
+        const method = () => false;
+        const message = 'Custom error';
+        validator.addMethod('CustomGroup', method, message, [ input ]);
+
+        expect(validator.getState().groups).toEqual({
+            group1: {
+                serverErrorNode: false,
+                validators: [{ type: 'required' }],
+                fields: [input],
+                valid: false
+            },
+            CustomGroup: {
+                serverErrorNode: false,
+                validators: [{ type: 'custom', method, message }],
+                fields: [input],
+                valid: false
+            }
+        });
+    });
+
 });

--- a/packages/validate/__tests__/unit/reducers.js
+++ b/packages/validate/__tests__/unit/reducers.js
@@ -251,6 +251,7 @@ describe('Validate > Unit > Reducers > Add validation method', () => {
             }
         });
     });
+    
     it('should add a validator of type custom and create a new group', async () => {
         expect.assertions(1);
         const validatorFn = (value, fields, param) => false;
@@ -277,6 +278,7 @@ describe('Validate > Unit > Reducers > Add validation method', () => {
             }
         });
     });
+    
     it('should add a validator and collect fields based on group data attribute', async () => {
         expect.assertions(1);
         const validatorFn = (value, fields, param) => false;
@@ -298,6 +300,38 @@ describe('Validate > Unit > Reducers > Add validation method', () => {
             groups: {
                 groupX: { //data attribute group name used as group key, not name attribute
                     fields,
+                    validators: [{ type: 'custom', validatorFn, message: 'This field can never be valid' }],
+                    serverErrorNode: false,
+                    valid: false
+                }
+            }
+        });
+    });
+
+    it('should add a validator with an array of fields', async () => {
+        expect.assertions(1);
+        const validatorFn = (value, fields, param) => false;
+        document.body.innerHTML = `<form class="form" method="post" action="">
+            <label for="group1">Text</label>
+            <input id="group1" name="group1"  type="text">
+        </form>`;
+        const input = document.getElementById('group1');
+        
+        const nextState = {
+            groupName: 'CustomGroup',
+            fields: [ input ],
+            validator: {
+                type: 'custom',
+                validatorFn,
+                message: 'This field can never be valid'
+            }
+        };
+        const state = { groups: {} };
+        const output = Reducers[ACTIONS.ADD_VALIDATION_METHOD](state, nextState);
+        expect(output).toEqual({
+            groups: {
+                CustomGroup: {
+                    fields: [ input ],
                     validators: [{ type: 'custom', validatorFn, message: 'This field can never be valid' }],
                     serverErrorNode: false,
                     valid: false

--- a/packages/validate/example/src/index.html
+++ b/packages/validate/example/src/index.html
@@ -185,7 +185,7 @@
         </div>
         <input type="submit" value="Submit">
     </form> -->
-    <form class="js-validate" action="#" autocomplete="off">
+    <!-- <form class="js-validate" action="#" autocomplete="off">
         <div class="form-group">
             <label for="RequiredString1">Required String</label>
             <input class="form-control" type="text" id="RequiredString1" name="RequiredString1" value="" required />
@@ -193,6 +193,17 @@
         <div class="form-group">
             <label for="Later">Required later</label>
             <input class="form-control" type="hidden" id="Later" name="something" value="" />
+        </div>
+        <input type="submit" value="Submit">
+    </form> -->
+    <form class="js-validate" action="#" autocomplete="off">
+        <div class="form-group">
+            <label for="f1">Maybe potato</label>
+            <input class="form-control" id="f1" name="f1" value="" required />
+        </div>
+        <div class="form-group">
+            <label for="f2">Also maybe potato</label>
+            <input class="form-control" id="f2" name="f2" value=""  />
         </div>
         <input type="submit" value="Submit">
     </form>

--- a/packages/validate/example/src/js/index.js
+++ b/packages/validate/example/src/js/index.js
@@ -1,6 +1,6 @@
 import validate from '../../../src';
 {
-    const validator = validate('form');
+    const [ validator ] = validate('form');
 
     // const later = document.getElementById('Later');
     // document.querySelector('.js-add').addEventListener('click', e => {
@@ -12,4 +12,18 @@ import validate from '../../../src';
     //         validator[0].addGroup([later]);
     //     }
     // });
+    const inputs = [ document.querySelector('#f1'), document.querySelector('#f2') ];
+    validator.addMethod(
+        'CustomGroup',
+        (value, fields) => {
+            console.log(value);
+            console.log(inputs);
+            return inputs[0].value.trim() === 'potato' || inputs[1].value.trim() === 'potato';
+        },
+        'One of the inputs must be the word "potato"',
+        inputs
+    );
+
+    console.log(validator.getState());
+
 };

--- a/packages/validate/src/lib/factory/add-method.js
+++ b/packages/validate/src/lib/factory/add-method.js
@@ -10,7 +10,7 @@ import { ACTIONS } from '../constants';
  * 
  */
 export const addMethod = Store => (groupName, method, message, fields) => {
-    if ((groupName === undefined || method === undefined || message === undefined) || !Store.getState()[groupName] && (document.getElementsByName(groupName).length === 0  && [].slice.call(document.querySelectorAll('[data-val-group="'+groupName+'"]')).length === 0) && !fields)
+    if ((groupName === undefined || method === undefined || message === undefined) || !Store.getState()[groupName] && (document.getElementsByName(groupName).length === 0  && [].slice.call(document.querySelectorAll(`[data-val-group="${groupName}"]`)).length === 0) && !fields)
         return console.warn('Custom validation method cannot be added.');
     Store.dispatch(ACTIONS.ADD_VALIDATION_METHOD, { groupName, fields, validator: { type: 'custom', method, message } });
 };

--- a/packages/validate/src/lib/factory/add-method.js
+++ b/packages/validate/src/lib/factory/add-method.js
@@ -9,8 +9,8 @@ import { ACTIONS } from '../constants';
  * @param message [String] Te error message displayed if the validation method returns false
  * 
  */
-export const addMethod = Store => (groupName, method, message) => {
-    if ((groupName === undefined || method === undefined || message === undefined) || !Store.getState()[groupName] && (document.getElementsByName(groupName).length === 0  && [].slice.call(document.querySelectorAll('[data-val-group="'+groupName+'"]')).length === 0))
+export const addMethod = Store => (groupName, method, message, fields) => {
+    if ((groupName === undefined || method === undefined || message === undefined) || !Store.getState()[groupName] && (document.getElementsByName(groupName).length === 0  && [].slice.call(document.querySelectorAll('[data-val-group="'+groupName+'"]')).length === 0) && !fields)
         return console.warn('Custom validation method cannot be added.');
-    Store.dispatch(ACTIONS.ADD_VALIDATION_METHOD, { groupName, validator: { type: 'custom', method, message } });
+    Store.dispatch(ACTIONS.ADD_VALIDATION_METHOD, { groupName, fields, validator: { type: 'custom', method, message } });
 };

--- a/packages/validate/src/lib/reducers/index.js
+++ b/packages/validate/src/lib/reducers/index.js
@@ -38,7 +38,7 @@ export default {
             state.groups[data.groupName]
                 ?  { validators: [...state.groups[data.groupName].validators, data.validator] }
                 : {
-                    fields: document.querySelector('[data-val-'+GROUP_ATTRIBUTE+'="'+data.groupName+'"]') ? [].slice.call(document.querySelectorAll('[data-val-'+GROUP_ATTRIBUTE+'="'+data.groupName+'"]')) : [].slice.call(document.getElementsByName(data.groupName)),
+                    fields: data.fields || (document.querySelector(`[data-val-${GROUP_ATTRIBUTE}="${data.groupName}"]`) ? [].slice.call(document.querySelectorAll(`[data-val-${GROUP_ATTRIBUTE}="${data.groupName}"]`)) : [].slice.call(document.getElementsByName(data.groupName))),
                     serverErrorNode: document.querySelector(`[${DOTNET_ERROR_SPAN_DATA_ATTRIBUTE}=${data.groupName}]`) || false,
                     valid: false,
                     validators: [data.validator],

--- a/packages/validate/src/lib/validator/methods.js
+++ b/packages/validate/src/lib/validator/methods.js
@@ -61,5 +61,5 @@ export default {
         })
             .then(data => resolve(data));
     }),
-    custom: (method, group) => isOptional(group)|| method(extractValueFromGroup(group), group.fields)
+    custom: (method, group) => isOptional(group) || method(extractValueFromGroup(group), group.fields)
 };


### PR DESCRIPTION
Addresses #172 

This PR improves the addMethod API for adding a custom validation group by allowing an array of fields to be passed rather than being constrained by name or data-group attributes of inputs.

This means that validation groups can slice across any combination of inputs and can include fields that are already in other validation groups, which was not previously possible.