### PR TITLE
Bug/138

### DIFF
--- a/packages/validate/__tests__/integration/real-time/index.js
+++ b/packages/validate/__tests__/integration/real-time/index.js
@@ -136,6 +136,8 @@ describe('Validate > Integration > Real-time', () => {
         expect(newLabel.lastElementChild.textContent).toEqual(defaults.messages.required());
 
         newInput.value="Sample";
+        const event = new Event('input', { bubbles: false });
+        newInput.dispatchEvent(event);
         expect(newLabel.querySelector('span')).toBeNull();
     });
     

--- a/packages/validate/__tests__/integration/real-time/index.js
+++ b/packages/validate/__tests__/integration/real-time/index.js
@@ -101,5 +101,42 @@ describe('Validate > Integration > Real-time', () => {
         input.dispatchEvent(event);
         expect(label.innerHTML).toEqual(cachedLabel);
     });
+
+    it('should run realtime validation after a new group is added post first validation', async () => {
+        expect.assertions(3);
+        document.body.innerHTML = `<form method="post" action="">
+            <label for="group1">Group1</label>
+            <input
+                type="checkbox"
+                id="group1"
+                name="group1"
+                required />
+        </form>`;
+
+        const form = document.querySelector('form');
+        const label = document.querySelector('label');
+        const [ validator ] = validate(form);
+        await validator.validate();
+        expect(label.lastElementChild.textContent).toEqual(defaults.messages.required());
+
+        const newLabel = document.createElement('label');
+        newLabel.textContent="Group2";
+        newLabel.setAttribute('for', 'group2');
+        form.appendChild(newLabel);
+
+        const newInput = document.createElement('input');
+        newInput.setAttribute('type', 'text');
+        newInput.setAttribute('id', 'group2');
+        newInput.setAttribute('name', 'group2');
+        newInput.required = true;
+        form.appendChild(newInput);
+
+        validator.addGroup([newInput]);
+        await validator.validate();
+        expect(newLabel.lastElementChild.textContent).toEqual(defaults.messages.required());
+
+        newInput.value="Sample";
+        expect(newLabel.querySelector('span')).toBeNull();
+    });
     
 });

--- a/packages/validate/src/lib/constants/index.js
+++ b/packages/validate/src/lib/constants/index.js
@@ -14,7 +14,8 @@ export const ACTIONS = {
     CLEAR_ERROR: 'CLEAR_ERROR',
     ADD_VALIDATION_METHOD: 'ADD_VALIDATION_METHOD',
     ADD_GROUP: 'ADD_GROUP',
-    REMOVE_GROUP: 'REMOVE_GROUP'
+    REMOVE_GROUP: 'REMOVE_GROUP',
+    START_REALTIME: 'START_REALTIME'
 };
 
 //https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address

--- a/packages/validate/src/lib/factory/group.js
+++ b/packages/validate/src/lib/factory/group.js
@@ -1,4 +1,5 @@
 import { removeUnvalidatableGroups, assembleValidationGroup } from '../validator';
+import { initRealTimeValidation } from '../validator/real-time-validation'
 import { clearError } from '../dom';
 import { ACTIONS } from '../constants';
 
@@ -13,7 +14,12 @@ export const addGroup = Store => nodes => {
     const groups = removeUnvalidatableGroups(nodes.reduce(assembleValidationGroup, {}));
     if (Object.keys(groups).length === 0) return console.warn('Group cannot be added.');
 
-    Store.dispatch(ACTIONS.ADD_GROUP, groups);
+    Store.dispatch(ACTIONS.ADD_GROUP, groups, [()=> {
+        if(Store.getState().realTimeValidation) {
+            //if we're already in realtime validation then we need to re-start it with the newly added group
+            initRealTimeValidation(Store);
+        }
+    }]);
 };
 
 /**

--- a/packages/validate/src/lib/reducers/index.js
+++ b/packages/validate/src/lib/reducers/index.js
@@ -64,7 +64,8 @@ export default {
                 })
             })
         });
-    }
+    },
+    [ACTIONS.START_REALTIME]: (state, data) => Object.assign({}, state, data),
 };
 
     

--- a/packages/validate/src/lib/validator/real-time-validation.js
+++ b/packages/validate/src/lib/validator/real-time-validation.js
@@ -43,18 +43,31 @@ export const initRealTimeValidation = Store => {
     };
 
     Object.keys(Store.getState().groups).forEach(groupName => {
-        Store.getState().groups[groupName].fields.forEach(input => {
-            input.addEventListener(resolveRealTimeValidationEvent(input), handler(groupName));
-        });
-        //;_; can do better?
-        const equalToValidator = Store.getState().groups[groupName].validators.filter(validator => validator.type === 'equalto');
+
+        const { groups } = Store.getState();
+        const groupUpdate = groups.slice();
         
-        if (equalToValidator.length > 0){
-            equalToValidator[0].params.other.forEach(subgroup => {
-                subgroup.forEach(item => {
-                    item.addEventListener('blur', handler(groupName));
-                });
+        if(!groupUpdate[groupName].hasEvent) {
+            groupUpdate[groupName].fields.forEach(input => {
+                input.addEventListener(resolveRealTimeValidationEvent(input), handler(groupName));
             });
+
+            //;_; can do better?
+            const equalToValidator = groupUpdate[groupName].validators.filter(validator => validator.type === 'equalto');
+            
+            if (equalToValidator.length > 0){
+                equalToValidator[0].params.other.forEach(subgroup => {
+                    subgroup.forEach(item => {
+                        item.addEventListener('blur', handler(groupName));
+                    });
+                });
+            }
+            
+            groupUpdate[groupName].hasEvent = true;
         }
+      
+        Store.dispatch(ACTIONS.START_REALTIME, {
+            groups: groupUpdate
+        });
     });
 };

--- a/packages/validate/src/lib/validator/real-time-validation.js
+++ b/packages/validate/src/lib/validator/real-time-validation.js
@@ -22,9 +22,9 @@ import {
  */
 export const initRealTimeValidation = Store => {
     const handler = groupName => () => {
-        const { groups } = Store.getState();
+        const { groups, errors } = Store.getState();
         
-        if (!groups[groupName].valid) {
+        if (!groups[groupName].valid && errors[groupName]) {
             Store.dispatch(ACTIONS.CLEAR_ERROR, groupName, [ clearError(groupName) ]);
         }
         getGroupValidityState(groups[groupName])

--- a/packages/validate/src/lib/validator/real-time-validation.js
+++ b/packages/validate/src/lib/validator/real-time-validation.js
@@ -45,7 +45,7 @@ export const initRealTimeValidation = Store => {
     Object.keys(Store.getState().groups).forEach(groupName => {
 
         const { groups } = Store.getState();
-        const groupUpdate = groups.slice();
+        const groupUpdate = {...groups};
         
         if(!groupUpdate[groupName].hasEvent) {
             groupUpdate[groupName].fields.forEach(input => {


### PR DESCRIPTION
Potential update for this

- When addGroup function is run, state is checked to see if we're already using realtime validation.  If we are, we re-initialise it.

- Realitime init function checks each group for the event before attaching a new one, in case group has already been processed

- Test added for the situation where a group is added post initial validation