### PR TITLE
Feature/161

### DIFF
--- a/packages/tabs/__tests__/integrations.js
+++ b/packages/tabs/__tests__/integrations.js
@@ -112,9 +112,11 @@ describe(`Tabs > Accessibility > keyboard events manual `, () => {
 
         TabSet[0].getState().tabs[0].dispatchEvent(right);
         expect(TabSet[0].getState().tabs[1].getAttribute('aria-selected')).toEqual('false');
+        expect(TabSet[0].getState().tabs[0].getAttribute('aria-selected')).toEqual('true');
         expect(TabSet[0].getState().tabs[1].classList.contains('is--active'));
         TabSet[0].getState().tabs[1].dispatchEvent(left);
-        expect(TabSet[0].getState().tabs[0].getAttribute('aria-selected')).toEqual('false');
+        expect(TabSet[0].getState().tabs[1].getAttribute('aria-selected')).toEqual('false');
+        expect(TabSet[0].getState().tabs[0].getAttribute('aria-selected')).toEqual('true');
         expect(TabSet[0].getState().tabs[0].classList.contains('is--active'));
     });
     

--- a/packages/tabs/__tests__/integrations.js
+++ b/packages/tabs/__tests__/integrations.js
@@ -2,7 +2,9 @@ import tabs from '../src';
 
 let TabSet;
 
-const init = () => {
+const init = (mode) => {
+
+    const activation = (mode) ? mode : "auto";
     // Set up our document body
     document.body.innerHTML = `<div role="tablist">
         <nav class="tabs__nav">
@@ -41,12 +43,12 @@ const init = () => {
         </section>
     </div>`;
 
-    TabSet = tabs('[role=tablist]');
+    TabSet = tabs('[role=tablist]', {activation: activation});
 };
 
 describe(`Tabs > Initialisation`, () => {
     
-    beforeAll(init);
+    beforeAll(() => {init()});
 
     it('should return array of length 1', async () => {
         expect(TabSet.length).toEqual(2);
@@ -67,6 +69,8 @@ describe(`Tabs > Initialisation`, () => {
     
 describe(`Tabs > Accessibility > ARIA`, () => {
 
+    beforeAll(() => {init()});
+
     it('should add correct attributes to tabs', async () => {
         expect(TabSet[0].getState().tabs[1].getAttribute('role')).toEqual('tab');
         expect(TabSet[0].getState().tabs[1].getAttribute('aria-selected')).toEqual('false');
@@ -82,7 +86,10 @@ describe(`Tabs > Accessibility > ARIA`, () => {
     
 });
 
-describe(`Tabs > Accessibility > keyboard events`, () => {
+describe(`Tabs > Accessibility > keyboard events auto `, () => {
+
+    beforeAll(() => {init()});
+
     it('should add keyboard event listener for the left and right keys to each tab', () => {
         const right = new window.KeyboardEvent('keydown', { keyCode: 39, bubbles: true });
         const left = new window.KeyboardEvent('keydown', { keyCode: 37, bubbles: true });
@@ -92,6 +99,30 @@ describe(`Tabs > Accessibility > keyboard events`, () => {
         TabSet[0].getState().tabs[1].dispatchEvent(left);
         expect(TabSet[0].getState().tabs[0].getAttribute('aria-selected')).toEqual('true');
     });
+    
+});
+
+describe(`Tabs > Accessibility > keyboard events manual `, () => {
+
+    beforeAll(() => {init("manual")});
+
+    it('should add keyboard event listener for the left and right keys to each tab', () => {
+        const right = new window.KeyboardEvent('keydown', { keyCode: 39, bubbles: true });
+        const left = new window.KeyboardEvent('keydown', { keyCode: 37, bubbles: true });
+
+        TabSet[0].getState().tabs[0].dispatchEvent(right);
+        expect(TabSet[0].getState().tabs[1].getAttribute('aria-selected')).toEqual('false');
+        expect(TabSet[0].getState().tabs[1].classList.contains('is--active'));
+        TabSet[0].getState().tabs[1].dispatchEvent(left);
+        expect(TabSet[0].getState().tabs[0].getAttribute('aria-selected')).toEqual('false');
+        expect(TabSet[0].getState().tabs[0].classList.contains('is--active'));
+    });
+    
+});
+
+describe(`Tabs > Accessibility > keyboard events both `, () => {
+
+    beforeAll(() => {init()});
     
     it('should add keyboard event listener for the space key to each tab', () => {
         const space = new window.KeyboardEvent('keydown', { keyCode: 32, bubbles: true });
@@ -130,6 +161,8 @@ describe(`Tabs > Accessibility > keyboard events`, () => {
 });
 
 describe(`Tabs > mouse events`, () => {
+    beforeAll(() => {init()});
+
     it('should click event listener for each tab', () => {
         const click = new MouseEvent('click', { bubbles: true, cancelable: true });
 

--- a/packages/tabs/example/src/js/index.js
+++ b/packages/tabs/example/src/js/index.js
@@ -1,5 +1,7 @@
 import tabs from '../../../src';
     
 window.addEventListener('DOMContentLoaded', () => {
-    tabs('[role=tablist]');
+    tabs('[role=tablist]', {
+        activation: 'manual'
+    });
 });

--- a/packages/tabs/example/src/js/index.js
+++ b/packages/tabs/example/src/js/index.js
@@ -2,6 +2,6 @@ import tabs from '../../../src';
     
 window.addEventListener('DOMContentLoaded', () => {
     tabs('[role=tablist]', {
-        activation: 'auto'
+        activation: 'manual'
     });
 });

--- a/packages/tabs/example/src/js/index.js
+++ b/packages/tabs/example/src/js/index.js
@@ -2,6 +2,6 @@ import tabs from '../../../src';
     
 window.addEventListener('DOMContentLoaded', () => {
     tabs('[role=tablist]', {
-        activation: 'manual'
+        activation: 'auto'
     });
 });

--- a/packages/tabs/src/lib/constants.js
+++ b/packages/tabs/src/lib/constants.js
@@ -12,5 +12,12 @@ export const KEYCODES = {
     DOWN: 40
 };
 
+/* @property activation, string, 'auto' or 'manual' describes tab activation method.  
+ as per https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-2/tabs.html or https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html */
+export const MODES = {
+    MANUAL:'manual',
+    AUTO: 'auto'
+}
+
 //Array of focusable child elements
 export const FOCUSABLE_ELEMENTS = ['a[href]', 'area[href]', 'input:not([disabled])', 'select:not([disabled])', 'textarea:not([disabled])', 'button:not([disabled])', 'iframe', 'object', 'embed', '[contenteditable]', '[tabindex]:not([tabindex="-1"])'];

--- a/packages/tabs/src/lib/defaults.js
+++ b/packages/tabs/src/lib/defaults.js
@@ -1,3 +1,4 @@
+import { MODES } from './constants';
 /* istanbul ignore file */
 /*
  * Default settings used by a Tabs instance if not otherwise overwritten with config
@@ -13,6 +14,6 @@ export default {
     tabSelector: '[role=tab]',
     activeClass: 'is--active',
     updateURL: true,
-    activation: 'auto',
+    activation: MODES.AUTO,
     activeIndex: 0
 };

--- a/packages/tabs/src/lib/defaults.js
+++ b/packages/tabs/src/lib/defaults.js
@@ -5,11 +5,14 @@
  * @property tabSelector, String, selector for a tab link  
  * @property currentClass, String, className added to active tab
  * @property updateURL, Boolean, to push tab fragment identifier to window location 
+ * @property activation, string, 'auto' or 'manual' describes tab activation method.  
+ * as per https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-2/tabs.html or https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html
  * @property active, Number, index of initially active tab
  */
 export default {
     tabSelector: '[role=tab]',
     activeClass: 'is--active',
     updateURL: true,
+    activation: 'auto',
     activeIndex: 0
 };

--- a/packages/tabs/src/lib/dom.js
+++ b/packages/tabs/src/lib/dom.js
@@ -106,12 +106,12 @@ const changeTab = (previousActiveTabIndex) => state => {
 
 const blurTab = ({ settings, tabs }, previousActiveTabIndex) => {
     tabs[previousActiveTabIndex].classList.remove(settings.activeClass);
-    tabs[previousActiveTabIndex].setAttribute('aria-selected', false);
     tabs[previousActiveTabIndex].setAttribute('tabindex', '-1');
 };
 
 const close = ({ settings, tabs, panels }, previousActiveIndex, previousActiveTabIndex) => {
     blurTab({settings, tabs}, previousActiveTabIndex);
+    tabs[previousActiveTabIndex].setAttribute('aria-selected', false);
     panels[previousActiveIndex].classList.remove(settings.activeClass);
     panels[previousActiveIndex].setAttribute('hidden', 'hidden');
     panels[previousActiveIndex].setAttribute('tabindex', '-1');
@@ -119,7 +119,6 @@ const close = ({ settings, tabs, panels }, previousActiveIndex, previousActiveTa
 
 const activateTab = ({ settings, tabs, activeTabIndex }) => {
     tabs[activeTabIndex].classList.add(settings.activeClass);
-    tabs[activeTabIndex].setAttribute('aria-selected', true);
     tabs[activeTabIndex].setAttribute('tabindex', 0);
 }
 
@@ -130,6 +129,7 @@ const focusTab = ({ tabs, activeTabIndex }) => {
 export const open = ({ settings, tabs, panels, activeIndex, activeTabIndex }) => {
     activateTab({settings, tabs, activeTabIndex})
     focusTab({tabs, activeTabIndex});
+    tabs[activeTabIndex].setAttribute('aria-selected', true);
     panels[activeIndex].classList.add(settings.activeClass);
     panels[activeIndex].removeAttribute('hidden');
     panels[activeIndex].setAttribute('tabindex', 0);

--- a/packages/tabs/src/lib/dom.js
+++ b/packages/tabs/src/lib/dom.js
@@ -1,4 +1,4 @@
-import { KEYCODES } from './constants';
+import { KEYCODES, MODES } from './constants';
 
 /*
  * DOM side effects and mutations
@@ -43,7 +43,7 @@ const getPreviousTabIndex = ({ activeTabIndex, tabs }) => activeTabIndex === 0 ?
 const getNextTabIndex = ({ activeTabIndex, tabs }) => activeTabIndex === tabs.length - 1 ? 0 : activeTabIndex + 1;
 
 const initListeners = (tab, nextIndex, Store) => {
-    const isManualActivation = Store.getState().settings.activation === 'manual';
+    const isManualActivation = Store.getState().settings.activation === MODES.MANUAL;
     const onDirectionChangeFunction = (isManualActivation) ? changeTab : changePanel;
 
     tab.addEventListener('keydown', e => {

--- a/packages/tabs/src/lib/dom.js
+++ b/packages/tabs/src/lib/dom.js
@@ -85,7 +85,10 @@ const initListeners = (tab, nextIndex, Store) => {
     
     tab.addEventListener('click', e => {
         e.preventDefault();
-        Store.getState().activeIndex !== nextIndex && Store.dispatch({ activeIndex: nextIndex }, [changePanel(Store.getState().activeIndex)]);
+        Store.getState().activeIndex !== nextIndex && Store.dispatch({ 
+            activeIndex: nextIndex,
+            activeTabIndex: nextIndex
+        }, [changePanel(Store.getState().activeIndex)]);
     }, false);
 };
 

--- a/packages/tabs/src/lib/dom.js
+++ b/packages/tabs/src/lib/dom.js
@@ -43,8 +43,8 @@ const getPreviousIndex = ({ activeIndex, tabs }) => activeIndex === 0 ? tabs.len
 const getNextIndex = ({ activeIndex, tabs }) => activeIndex === tabs.length - 1 ? 0 : activeIndex + 1;
 
 const initListeners = (tab, nextIndex, Store) => {
-    const isAutoActivation = Store.getState().settings.activation === 'auto';
-    const onDirectionChangeFunction = (isAutoActivation) ? changePanel : changeTab;
+    const isManualActivation = Store.getState().settings.activation === 'manual';
+    const onDirectionChangeFunction = (isManualActivation) ? changeTab : changePanel;
 
     tab.addEventListener('keydown', e => {
         switch (e.keyCode) {

--- a/packages/tabs/src/lib/dom.js
+++ b/packages/tabs/src/lib/dom.js
@@ -60,11 +60,11 @@ const initListeners = (tab, nextIndex, Store) => {
             Store.dispatch({ activeIndex: getNextIndex(Store.getState()) }, [onDirectionChangeFunction(Store.getState().activeIndex)]);
             break;
         case KEYCODES.ENTER:
-            Store.getState().activeIndex !== nextIndex && Store.dispatch({ activeIndex: nextIndex }, [changePanel(Store.getState().activeIndex)]);
+            Store.dispatch({ activeIndex: nextIndex }, [changePanel(Store.getState().activeIndex)]);
             break;
         case KEYCODES.SPACE:
             e.preventDefault();
-            Store.getState().activeIndex !== nextIndex && Store.dispatch({ activeIndex: nextIndex }, [changePanel(Store.getState().activeIndex)]);
+            Store.dispatch({ activeIndex: nextIndex }, [changePanel(Store.getState().activeIndex)]);
             break;
         default:
             break;
@@ -78,6 +78,7 @@ const initListeners = (tab, nextIndex, Store) => {
 };
 
 const changePanel = previousActiveIndex => state => {
+    console.log(previousActiveIndex);
     close(state, previousActiveIndex);
     open(state);
     window.setTimeout(() => { state.tabs[state.activeIndex].focus(); }, 16);

--- a/packages/tabs/src/lib/factory.js
+++ b/packages/tabs/src/lib/factory.js
@@ -16,7 +16,7 @@ export default ({ node, settings }) => {
         settings,
         node,
         activeIndex: activeIndex !== undefined ? +activeIndex : +settings.activeIndex,
-        activeTabIndex: activeIndex, 
+        activeTabIndex: activeIndex !== undefined ? +activeIndex : +settings.activeIndex,
         tabs,
         panels
     }, [ initUI(Store), open ]);

--- a/packages/tabs/src/lib/factory.js
+++ b/packages/tabs/src/lib/factory.js
@@ -16,7 +16,8 @@ export default ({ node, settings }) => {
         settings,
         node,
         activeIndex: activeIndex !== undefined ? +activeIndex : +settings.activeIndex,
-        activeTabIndex: activeIndex !== undefined ? +activeIndex : +settings.activeIndex,
+        //activeTabIndex should initially match the active panel, so initialising here to the same value
+        activeTabIndex: activeIndex !== undefined ? +activeIndex : +settings.activeIndex, 
         tabs,
         panels
     }, [ initUI(Store), open ]);

--- a/packages/tabs/src/lib/factory.js
+++ b/packages/tabs/src/lib/factory.js
@@ -16,6 +16,7 @@ export default ({ node, settings }) => {
         settings,
         node,
         activeIndex: activeIndex !== undefined ? +activeIndex : +settings.activeIndex,
+        activeTabIndex: activeIndex, 
         tabs,
         panels
     }, [ initUI(Store), open ]);


### PR DESCRIPTION
Looks at implementing the enhancement from [issue 161](https://github.com/stormid/components/issues/161).

- Adds 'activation' as an option to initialise the module.  Set to 'auto' by default, or if anything other than the string 'manual' is passed in the options object.
- ActiveTabIndex is now tracked separately from the ActivePanelIndex in the state, as with manual activation the two are not necessarily the same.
- Activate/blur functions have been added separately for the tabs and panels to handle this difference.  
- Other tab/spacebar/enter keyboard listeners remain the same.

