### PR TITLE
Check for aria-described by attribute before usage in clear error

### DIFF
--- a/packages/validate/src/lib/dom/index.js
+++ b/packages/validate/src/lib/dom/index.js
@@ -63,8 +63,10 @@ export const clearError = groupName => state => {
         const describedbyid = ((state.groups[groupName].serverErrorNode || state.errors[groupName]).id);
 
         //check whether the aria-describedby matches the id, if not another id must be present, only replace the removed error id
-        if (field.getAttribute('aria-describedby') === describedbyid) field.removeAttribute('aria-describedby');
-        else field.setAttribute('aria-describedby', field.getAttribute('aria-describedby').replace(` ${describedbyid}`, ''));
+        if(field.hasAttribute('aria-describedby')) {
+            if (field.getAttribute('aria-describedby') === describedbyid) field.removeAttribute('aria-describedby');
+            else field.setAttribute('aria-describedby', field.getAttribute('aria-describedby').replace(` ${describedbyid}`, ''));
+        }
     });
     delete state.errors[groupName];//shouldn't be doing this here...
 };


### PR DESCRIPTION
Spotted an error in a project this morning where the project required a call to removeGroup() before the form was validated.  

This causes a call to the clearError function, which was assuming the aria-describedby attribute existed.

Updated the function to check for this existence before using the attribute.