### PR TITLE
Adding a condition to check for the existence of error messages before render

### DIFF
--- a/packages/validate/src/lib/dom/index.js
+++ b/packages/validate/src/lib/dom/index.js
@@ -114,23 +114,25 @@ export const renderError = groupName => state => {
     //shouldn't be updating state here...
     //to do: refactor to update state as a side effect afterwards?
     //would need to pass Store instead of state
-    if (state.groups[groupName].serverErrorNode) state.errors[groupName] = createErrorTextNode(state.groups[groupName], state.groups[groupName].errorMessages[0]);
-    else {
-        const label = document.querySelector(`[for="${state.groups[groupName].fields[state.groups[groupName].fields.length-1].getAttribute('id')}"]`);
-        state.errors[groupName] = label.parentNode.insertBefore(h('span', { class: DOTNET_CLASSNAMES.ERROR, id: `${groupName}-error-message` }, state.groups[groupName].errorMessages[0]), label.nextSibling);
-    }
-    const errorContainer = state.groups[groupName].serverErrorNode || state.errors[groupName];
-						
-    state.groups[groupName].fields.forEach(field => {
-        field.parentNode.classList.add('is--invalid');
-        field.setAttribute('aria-invalid', 'true');
-        if (!field.hasAttribute('aria-describedby') || !hasAriaDescribedbyValue(field, errorContainer.getAttribute('id'))) {
-            field.setAttribute('aria-describedby', (field.hasAttribute('aria-describedby')
-                ? `${field.getAttribute('aria-describedby')} ${errorContainer.getAttribute('id')}`
-                : errorContainer.getAttribute('id'))
-            );
+    if(typeof state.groups[groupName].errorMessages !== 'undefined') {
+        if (state.groups[groupName].serverErrorNode) state.errors[groupName] = createErrorTextNode(state.groups[groupName], state.groups[groupName].errorMessages[0]);
+        else {
+            const label = document.querySelector(`[for="${state.groups[groupName].fields[state.groups[groupName].fields.length-1].getAttribute('id')}"]`);
+            state.errors[groupName] = label.parentNode.insertBefore(h('span', { class: DOTNET_CLASSNAMES.ERROR, id: `${groupName}-error-message` }, state.groups[groupName].errorMessages[0]), label.nextSibling);
         }
-    });
+        const errorContainer = state.groups[groupName].serverErrorNode || state.errors[groupName];
+                            
+        state.groups[groupName].fields.forEach(field => {
+            field.parentNode.classList.add('is--invalid');
+            field.setAttribute('aria-invalid', 'true');
+            if (!field.hasAttribute('aria-describedby') || !hasAriaDescribedbyValue(field, errorContainer.getAttribute('id'))) {
+                field.setAttribute('aria-describedby', (field.hasAttribute('aria-describedby')
+                    ? `${field.getAttribute('aria-describedby')} ${errorContainer.getAttribute('id')}`
+                    : errorContainer.getAttribute('id'))
+                );
+            }
+        });
+    }
 };
 
 


### PR DESCRIPTION
Spotted a non-breaking console warning in a project this afternoon.  Issue arose because:

- The form had been submitted with errors and was in the 'real time validation' state
- A group was added while in this state, and as per the recent bug fix the real-time-validation was restarted again with the new group in place
- The new group immediately failed validation because it was required, but had just been added and had no value.
- The addition of the error message failed with a console warning via a catch statement, because the new input had not been through the ACTIONS.VALIDATION_ERRORS reducer which adds the errorMessages array.  

Potential solution is just to check for the existence of the errorMessage array in the renderError function before running.  This would solve the above console error, and mean that any inputs added during realtime validation would still only get their first validation run via the user's input event or another form submission. 