### PR TITLE
Feature/177

### DIFF
--- a/packages/validate/README.md
+++ b/packages/validate/README.md
@@ -302,7 +302,10 @@ If this element is not present a span is appended to the label for the field wit
 
 Fields without data-val error messages will show the default messages for the failed validator (see options below).
 
-To include the user input value in your error message, place a token "{{value}}" within the message string and the script will replace it at the time of validation.  eg "{{value}} is not a valid email address" will become "test@test is not a valid email address"
+#### Including values in error messages
+To include the user input value in your error message, place a token "{{value}}" within the message string and the script will replace it at the time of validation.  e.g. "{{value}} is not a valid email address" will become "test@test is not a valid email address".  
+
+If a validation group contains more than one field, the values of these will be returned as a comma seperated list within the message.  For example:  "{{value}} are not valid inputs" becomes "test1, test2 are not valid inputs".
 
 
 ## Options

--- a/packages/validate/README.md
+++ b/packages/validate/README.md
@@ -302,6 +302,8 @@ If this element is not present a span is appended to the label for the field wit
 
 Fields without data-val error messages will show the default messages for the failed validator (see options below).
 
+To include the user input value in your error message, place a token "{{value}}" within the message string and the script will replace it at the time of validation.  eg "{{value}} is not a valid email address" will become "test@test is not a valid email address"
+
 
 ## Options
 

--- a/packages/validate/__tests__/integration/errors/index.js
+++ b/packages/validate/__tests__/integration/errors/index.js
@@ -68,4 +68,26 @@ describe('Validate > Integration > errors', () => {
         expect(errorContainer.firstChild.textContent).toEqual(defaults.messages.required());
     });
 
+    it('Should render the invalid input value in the error message if the {{value}} token is used in the supplied error message', async () => {
+        expect.assertions(1);
+        document.body.innerHTML = `<form class="form">
+            <label id="group1-1-label" for="group1-1">group1</label>
+            <input
+                id="group1-1"
+                name="group1"
+                data-val="true"
+                data-val-email="{{value}} is not a valid email address"
+                value="test"
+                type="email"
+                aria-describedby="ssec"
+            />
+            <span id="ssec" data-valmsg-for="group1"></span>
+        </form>`;
+        const [ validator ] = validate('form');
+        await validator.validate();
+        const errorContainer = document.getElementById('ssec');
+        //render error message
+        expect(errorContainer.textContent).toEqual('test is not a valid email address');
+    });
+
 });

--- a/packages/validate/__tests__/unit/dom/errors.js
+++ b/packages/validate/__tests__/unit/dom/errors.js
@@ -366,4 +366,31 @@ describe('Validate > Unit > DOM > updateMessageValues', () => {
         
     });
 
+    it('Should leave the error message unchanged if the {{value}} token is not found', async () => {
+        document.body.innerHTML = `<form class="form" method="post" action="">
+            <div>
+                <label id="test-label" for="group1">Text</label>
+                <input id="group1" name="group1" value="test" data-val="true" data-val-regex="These are not valid inputs" data-val-regex-pattern="^http(s)?">
+            </div>
+            <div>
+                <label id="test-label2" for="group2">Text</label>
+                <input id="group2" name="group1" value="test2" data-val="true" data-val-regex="These are not valid inputs" data-val-regex-pattern="^http(s)?">
+            </div>
+        </form>`;
+        const mockState = {
+            groups: {
+                group1: {
+                    serverErrorNode: false,
+                    fields: Array.from(document.getElementsByName('group1')),
+                    errorMessages: ['These are not valid inputs'],
+                    valid: false
+                }
+            },
+            errors: {}
+        };
+        let message = updateMessageValues(mockState, 'group1');
+        expect(message).toEqual('These are not valid inputs');
+        
+    });
+
 });

--- a/packages/validate/__tests__/unit/dom/errors.js
+++ b/packages/validate/__tests__/unit/dom/errors.js
@@ -3,7 +3,8 @@ import {
     clearError,
     clearErrors,
     renderError,
-    renderErrors
+    renderErrors,
+    updateMessageValues
 } from '../../../src/lib/dom';
 import { DOTNET_CLASSNAMES } from '../../../src/lib/constants';
 
@@ -306,6 +307,63 @@ describe('Validate > Unit > DOM > renderErrors', () => {
         expect(mockState.groups.group2.fields[0].parentNode.classList.contains('is--invalid')).toEqual(false);
         expect(mockState.groups.group2.fields[0].getAttribute('aria-invalid')).toEqual(null);
         expect(mockState.groups.group1.fields[0].getAttribute('aria-describedby')).toEqual(errorContainer.id);
+    });
+
+});
+
+
+//updateMessageValues
+describe('Validate > Unit > DOM > updateMessageValues', () => {
+    
+    it('Should return an error message string containing the input value if the {{value}} token is found in the error message', async () => {
+        document.body.innerHTML = `<form class="form" method="post" action="">
+            <div>
+                <label id="test-label" for="group1">Text</label>
+                <input id="group1" name="group1" value="test" data-val="true" type="email" data-val-email="{{value}} is not a valid email address">
+            </div>
+           
+        </form>`;
+        const mockState = {
+            groups: {
+                group1: {
+                    serverErrorNode: false,
+                    fields: Array.from(document.getElementsByName('group1')),
+                    errorMessages: ['{{value}} is not a valid email address'],
+                    valid: false
+                }
+            },
+            errors: {}
+        };
+        let message = updateMessageValues(mockState, 'group1');
+        expect(message).toEqual('test is not a valid email address');
+        
+    });
+
+    it('Should return an error message with a comma delimited string of values if more than one field is in a group', async () => {
+        document.body.innerHTML = `<form class="form" method="post" action="">
+            <div>
+                <label id="test-label" for="group1">Text</label>
+                <input id="group1" name="group1" value="test" data-val="true" data-val-regex="{{value}} are not valid inputs" data-val-regex-pattern="^http(s)?">
+            </div>
+            <div>
+                <label id="test-label2" for="group2">Text</label>
+                <input id="group2" name="group1" value="test2" data-val="true" data-val-regex="{{value}} are not valid inputs" data-val-regex-pattern="^http(s)?">
+            </div>
+        </form>`;
+        const mockState = {
+            groups: {
+                group1: {
+                    serverErrorNode: false,
+                    fields: Array.from(document.getElementsByName('group1')),
+                    errorMessages: ['{{value}} are not valid inputs'],
+                    valid: false
+                }
+            },
+            errors: {}
+        };
+        let message = updateMessageValues(mockState, 'group1');
+        expect(message).toEqual('test, test2 are not valid inputs');
+        
     });
 
 });

--- a/packages/validate/example/src/index.html
+++ b/packages/validate/example/src/index.html
@@ -200,7 +200,7 @@
         <div class="form-group">
             <label for="f1">Field 1</label>
             <span data-valmsg-for="f1"></span>
-            <input class="form-control" id="f1" name="f1" value="" data-val="true" data-val-required="This field is required" />
+            <input class="form-control" id="f1" name="f1" value="" data-val="true" data-val-required="This field is required" type="email" data-val-email="{{value}} is not a valid email address"/>
         </div>
         <div class="form-group">
             <label for="f2">Field 2</label>

--- a/packages/validate/example/src/js/index.js
+++ b/packages/validate/example/src/js/index.js
@@ -13,16 +13,16 @@ import validate from '../../../src';
     //     }
     // });
     const inputs = [ document.querySelector('#f1'), document.querySelector('#f2') ];
-    validator.addMethod(
-        'CustomGroup',
-        (value, fields) => {
-            console.log(value);
-            console.log(inputs);
-            return inputs[0].value.trim() === 'potato' || inputs[1].value.trim() === 'potato';
-        },
-        'One of the inputs must be the word "potato"',
-        inputs
-    );
+    // validator.addMethod(
+    //     'CustomGroup',
+    //     (value, fields) => {
+    //         console.log(value);
+    //         console.log(inputs);
+    //         return inputs[0].value.trim() === 'potato' || inputs[1].value.trim() === 'potato';
+    //     },
+    //     'One of the inputs must be the word "potato"',
+    //     inputs
+    // );
 
     console.log(validator.getState());
 

--- a/packages/validate/src/lib/constants/index.js
+++ b/packages/validate/src/lib/constants/index.js
@@ -79,3 +79,7 @@ export const DOTNET_CLASSNAMES = {
 };
 
 export const GROUP_ATTRIBUTE = 'group';
+
+export const TOKENS = {
+    VALUE: '{{value}}'
+}

--- a/packages/validate/src/lib/defaults/index.js
+++ b/packages/validate/src/lib/defaults/index.js
@@ -1,10 +1,10 @@
 export default {
     messages: {
         required() { return 'This field is required'; } ,
-        email() { return 'Enter a valid email address'; },
-        pattern() { return 'The value must match the pattern'; },
-        url(){ return 'Enter a valid URL'; },
-        number() { return 'Enter a valid number'; },
+        email() { return '{{value}} is not a valid email address'; },
+        pattern() { return '{{value}} does not match the pattern'; },
+        url(){ return '{{value}} is not valid URL'; },
+        number() { return '{{value}} is not a valid number'; },
         maxlength(props) { return `Enter no more than ${props.max} characters`; },
         minlength(props) { return `Enter at least ${props.min} characters`; },
         max(props){ return `Enter a value less than or equal to ${props.max}`; },

--- a/packages/validate/src/lib/defaults/index.js
+++ b/packages/validate/src/lib/defaults/index.js
@@ -1,10 +1,10 @@
 export default {
     messages: {
         required() { return 'This field is required'; } ,
-        email() { return '{{value}} is not a valid email address'; },
-        pattern() { return '{{value}} does not match the pattern'; },
-        url(){ return '{{value}} is not valid URL'; },
-        number() { return '{{value}} is not a valid number'; },
+        email() { return 'Enter a valid email address'; },
+        pattern() { return 'The value must match the pattern'; },
+        url(){ return 'Enter a valid URL'; },
+        number() { return 'Enter a valid number'; },
         maxlength(props) { return `Enter no more than ${props.max} characters`; },
         minlength(props) { return `Enter at least ${props.min} characters`; },
         max(props){ return `Enter a value less than or equal to ${props.max}`; },

--- a/packages/validate/src/lib/dom/index.js
+++ b/packages/validate/src/lib/dom/index.js
@@ -107,9 +107,9 @@ export const renderErrors = state => {
  export const updateMessageValues = (state, groupName) => {
     let msg = state.groups[groupName].errorMessages[0];
 
-    let values = state.groups[groupName].fields.reduce((acc, field, index, array) => {
-        if(index === array.length-1) return acc + field.value;
-        return acc = field.value + ", ";
+    let values = state.groups[groupName].fields.reduce((newMsg, field, index, array) => {
+        if(index === array.length-1) return newMsg + field.value;
+        return newMsg = field.value + ", ";
     }, "");
 
     return msg.replace(TOKENS.VALUE, values);

--- a/packages/validate/src/lib/dom/index.js
+++ b/packages/validate/src/lib/dom/index.js
@@ -108,9 +108,9 @@ export const renderErrors = state => {
     let msg = state.groups[groupName].errorMessages[0];
 
     let values = state.groups[groupName].fields.reduce((acc, field, index, array) => {
-        if(index === array.length-1) return acc;
-        return acc = acc + ", " + field.value;
-    }, state.groups[groupName].fields[0].value);
+        if(index === array.length-1) return acc + field.value;
+        return acc = field.value + ", ";
+    }, "");
 
     return msg.replace(TOKENS.VALUE, values);
 };

--- a/packages/validate/src/lib/dom/index.js
+++ b/packages/validate/src/lib/dom/index.js
@@ -1,4 +1,4 @@
-import { DOTNET_CLASSNAMES } from '../constants';
+import { DOTNET_CLASSNAMES, TOKENS } from '../constants';
 
 /**
  * Hypertext DOM factory function
@@ -30,7 +30,8 @@ export const h = (nodeName, attributes, text) => {
  * @returns node [Text node]
  * 
  */
-export const createErrorTextNode = (group, msg) => {
+export const createErrorTextNode = (group, msg) => {    
+
     let node = document.createTextNode(msg);
     group.serverErrorNode.classList.remove(DOTNET_CLASSNAMES.VALID);
     group.serverErrorNode.classList.add(DOTNET_CLASSNAMES.ERROR);
@@ -95,6 +96,26 @@ export const renderErrors = state => {
     });
 };
 
+
+/**
+ * Looks for any value tokens and replaces them within the error message
+ * 
+ * @param state [Object, validation state]
+ * @param groupName [String, validation group] 
+ * 
+ */
+ export const updateMessageValues = (state, groupName) => {
+    let msg = state.groups[groupName].errorMessages[0];
+
+    let values = state.groups[groupName].fields.reduce((acc, field, index, array) => {
+        if(index === array.length-1) return acc;
+        return acc = acc + ", " + field.value;
+    }, state.groups[groupName].fields[0].value);
+
+    return msg.replace(TOKENS.VALUE, values);
+};
+
+
 /**
  * Adds an error message to the DOM and saves it to local scope
  * 
@@ -110,14 +131,16 @@ export const renderErrors = state => {
  */
 export const renderError = groupName => state => {
     if (state.errors[groupName]) clearError(groupName)(state);
-    
+
+    let msg = updateMessageValues(state, groupName);
+
     //shouldn't be updating state here...
     //to do: refactor to update state as a side effect afterwards?
     //would need to pass Store instead of state
-    if (state.groups[groupName].serverErrorNode) state.errors[groupName] = createErrorTextNode(state.groups[groupName], state.groups[groupName].errorMessages[0]);
+    if (state.groups[groupName].serverErrorNode) state.errors[groupName] = createErrorTextNode(state.groups[groupName], msg);
     else {
         const label = document.querySelector(`[for="${state.groups[groupName].fields[state.groups[groupName].fields.length-1].getAttribute('id')}"]`);
-        state.errors[groupName] = label.parentNode.insertBefore(h('span', { class: DOTNET_CLASSNAMES.ERROR, id: `${groupName}-error-message` }, state.groups[groupName].errorMessages[0]), label.nextSibling);
+        state.errors[groupName] = label.parentNode.insertBefore(h('span', { class: DOTNET_CLASSNAMES.ERROR, id: `${groupName}-error-message` }, msg), label.nextSibling);
     }
     const errorContainer = state.groups[groupName].serverErrorNode || state.errors[groupName];
 						


### PR DESCRIPTION
Possible addition for #177 .

Developer can place a {{value}} token within their error message string to have the user-inputted value display within the error message at the point of validation.

If the group contains more than one field, the values are concatenated with commas.   No other edits are made to the error message, so it would require the developer to know that there were multiple values and format the error message as such.

Unit and integration tests added for new string replacement function.