### PR TITLE
Async validators

### DIFF
--- a/packages/validate/__tests__/integration/api/validate/equalto.js
+++ b/packages/validate/__tests__/integration/api/validate/equalto.js
@@ -22,7 +22,7 @@ describe('Validate > Integration >  api > validate > equalto', () => {
                 name="DoubleConfirmEmail"
                 value="not.the.same.email.address@stormid.com" /></form>`;
         const input = document.querySelector('#DoubleConfirmEmail');
-        const label = document.getElementById('DoubleConfirmEmail-label');
+        // const label = document.getElementById('DoubleConfirmEmail-label');
         const validator = library('form')[0];
         const validityState = await validator.validate();
         // //validityState
@@ -54,7 +54,7 @@ describe('Validate > Integration >  api > validate > equalto', () => {
                 value="example@stormid.com" />`;
         const input = document.querySelector('#DoubleConfirmEmail');
         const group = assembleValidationGroup({}, input).DoubleConfirmEmail;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
 });

--- a/packages/validate/__tests__/integration/api/validate/remote.js
+++ b/packages/validate/__tests__/integration/api/validate/remote.js
@@ -13,7 +13,7 @@ describe('Validate > Integration > api > validate > remote', () => {
  
         mock.post('/api/validate', {
             status: 201,
-            body: 'false'
+            body: 'Remote error message'
         });
         document.body.innerHTML = `<form class="form">
             <label id="group1-label" for="group1">Label</label>

--- a/packages/validate/__tests__/integration/validator/custom.js
+++ b/packages/validate/__tests__/integration/validator/custom.js
@@ -21,7 +21,7 @@ describe('Validate > Integration > validator > custom', () => {
                     }
                 }]
         };
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for custom validator that fails', async () => {
@@ -43,7 +43,31 @@ describe('Validate > Integration > validator > custom', () => {
                     }
                 }]
         };
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
+    });
+
+    it('should support asynchronous custom validators', async () => {
+        expect.assertions(1);
+        document.body.innerHTML = `<input
+			id="group1"
+            name="group1"
+            value="no"
+			type="text">`;
+        const input = document.querySelector('#group1');
+        const group = {
+            valid: false,
+            fields: [input],
+            validators: [
+                {
+                    type: 'custom',
+                    method(value, fields) {
+                        return new Promise(resolve => {
+                            setTimeout(() => resolve(value === 'no'), 100);
+                        });
+                    }
+                }]
+        };
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
 });

--- a/packages/validate/__tests__/integration/validator/dateISO.js
+++ b/packages/validate/__tests__/integration/validator/dateISO.js
@@ -13,7 +13,7 @@ describe('Validate > Integration > validator > dateISO', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for data-val dateISO validator with an on-spec date', async () => {
@@ -27,7 +27,7 @@ describe('Validate > Integration > validator > dateISO', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 });
 

--- a/packages/validate/__tests__/integration/validator/digits.js
+++ b/packages/validate/__tests__/integration/validator/digits.js
@@ -13,7 +13,7 @@ describe('Validate > Integration > validator > digits', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for data-val digits validator with an no-spec date', async () => {
@@ -27,7 +27,7 @@ describe('Validate > Integration > validator > digits', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
     
 });

--- a/packages/validate/__tests__/integration/validator/email.js
+++ b/packages/validate/__tests__/integration/validator/email.js
@@ -12,7 +12,7 @@ describe('Validate > Integration > validator > email', () => {
 			type="email">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for HTML5 email validator with an on-spec email address', async () => {
@@ -24,7 +24,7 @@ describe('Validate > Integration > validator > email', () => {
 			type="email">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for non-required empty HTML5 email validator field', async () => {
@@ -36,7 +36,7 @@ describe('Validate > Integration > validator > email', () => {
 			type="email">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState false for data-val email validator with non-spec email address', async () => {
@@ -50,7 +50,7 @@ describe('Validate > Integration > validator > email', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for data-val email validator with an on-spec email address', async () => {
@@ -64,7 +64,7 @@ describe('Validate > Integration > validator > email', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for non-required empty data-val email validator field', async () => {
@@ -78,7 +78,7 @@ describe('Validate > Integration > validator > email', () => {
 			type="email">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
 });

--- a/packages/validate/__tests__/integration/validator/equalto.js
+++ b/packages/validate/__tests__/integration/validator/equalto.js
@@ -25,7 +25,7 @@ describe('Validate > Integration > validator > equalto', () => {
             />`;
         const input = document.querySelector('#VERIFY-EMAIL');
         const group = assembleValidationGroup({}, input)['VERIFY-EMAIL'];
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for data-val equalto validator with a value matching another single field', async () => {
@@ -51,7 +51,7 @@ describe('Validate > Integration > validator > equalto', () => {
             />`;
         const input = document.querySelector('#VERIFY-EMAIL');
         const group = assembleValidationGroup({}, input)['VERIFY-EMAIL'];
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState false for data-val equalto validator with a value not matching the other field(s)', async () => {
@@ -72,7 +72,7 @@ describe('Validate > Integration > validator > equalto', () => {
                 value="not.the.same.email.address@stormid.com" />`;
         const input = document.querySelector('#DoubleConfirmEmail');
         const group = assembleValidationGroup({}, input).DoubleConfirmEmail;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState false for data-val equalto validator with a value not matching the other field(s) with an empty value', async () => {
@@ -93,7 +93,7 @@ describe('Validate > Integration > validator > equalto', () => {
                 value="example@stormid.com" />`;
         const input = document.querySelector('#DoubleConfirmEmail');
         const group = assembleValidationGroup({}, input).DoubleConfirmEmail;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for data-val equalto validator with a value matching the other field(s)', async () => {
@@ -114,7 +114,7 @@ describe('Validate > Integration > validator > equalto', () => {
                 value="example@stormid.com" />`;
         const input = document.querySelector('#DoubleConfirmEmail');
         const group = assembleValidationGroup({}, input).DoubleConfirmEmail;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for an unrequired data-val equalto validator with no value', async () => {
@@ -135,7 +135,7 @@ describe('Validate > Integration > validator > equalto', () => {
                 value="" />`;
         const input = document.querySelector('#DoubleConfirmEmail');
         const group = assembleValidationGroup({}, input).DoubleConfirmEmail;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
 });

--- a/packages/validate/__tests__/integration/validator/index.js
+++ b/packages/validate/__tests__/integration/validator/index.js
@@ -23,7 +23,7 @@ describe('Validate > Integration > validator > error handling', () => {
                     }
                 }]
         };
-        validate(group, group.validators[0]);
+        await validate(group, group.validators[0]);
         expect(console.warn).toHaveBeenCalledWith(errorMessage);
     });
 

--- a/packages/validate/__tests__/integration/validator/isHidden.js
+++ b/packages/validate/__tests__/integration/validator/isHidden.js
@@ -16,7 +16,7 @@ describe('Validate > Integration > assembleValidationGroup > With hidden element
             value=""
             type="hidden">`;
         const inputs = [].slice.call(document.querySelectorAll('[name="group1"]'));
-        const group = inputs.reduce(assembleValidationGroup, {}); 
+        const group = inputs.reduce(assembleValidationGroup, {});
         expect(group.group1.fields).toEqual([inputs[0]]);
     });
 

--- a/packages/validate/__tests__/integration/validator/length.js
+++ b/packages/validate/__tests__/integration/validator/length.js
@@ -15,7 +15,7 @@ describe('Validate > Integration > validator > length', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for data-val length validator with value within the min and max length range', async () => {
@@ -31,7 +31,7 @@ describe('Validate > Integration > validator > length', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for unrequired data-val length validator with no value', async () => {
@@ -47,7 +47,7 @@ describe('Validate > Integration > validator > length', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
 });

--- a/packages/validate/__tests__/integration/validator/max.js
+++ b/packages/validate/__tests__/integration/validator/max.js
@@ -12,7 +12,7 @@ describe('Validate > Integration > validator > max', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState false for data-val max validator with value greater than max', async () => {
@@ -27,7 +27,7 @@ describe('Validate > Integration > validator > max', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for HTML5 max validator with value less than or equal to max', async () => {
@@ -40,7 +40,7 @@ describe('Validate > Integration > validator > max', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for data-val max validator with value less or equal to max', async () => {
@@ -55,7 +55,7 @@ describe('Validate > Integration > validator > max', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState false for HTML5 max validator with a non-numeric value', async () => {
@@ -68,7 +68,7 @@ describe('Validate > Integration > validator > max', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState false for data-val max validator with a non-numeric value', async () => {
@@ -83,7 +83,7 @@ describe('Validate > Integration > validator > max', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for unrequired HTML5 max validator with no value', async () => {
@@ -96,7 +96,7 @@ describe('Validate > Integration > validator > max', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for unrequired data-val max validator with no value', async () => {
@@ -111,7 +111,7 @@ describe('Validate > Integration > validator > max', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
 

--- a/packages/validate/__tests__/integration/validator/maxlength.js
+++ b/packages/validate/__tests__/integration/validator/maxlength.js
@@ -14,7 +14,7 @@ describe('Validate > Integration > validator > maxlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for data-val maxlength validator with value length less than the max', async () => {
@@ -29,7 +29,7 @@ describe('Validate > Integration > validator > maxlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for unrequired data-val maxlength validator with no value', async () => {
@@ -44,7 +44,7 @@ describe('Validate > Integration > validator > maxlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState false for HTML5 maxlength validator with value length greater than max', async () => {
@@ -57,7 +57,7 @@ describe('Validate > Integration > validator > maxlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState false for HTML5 maxlength validator with value length less than max', async () => {
@@ -70,7 +70,7 @@ describe('Validate > Integration > validator > maxlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for unrequired HTML5 maxlength validator with no value', async () => {
@@ -83,7 +83,7 @@ describe('Validate > Integration > validator > maxlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
 });

--- a/packages/validate/__tests__/integration/validator/min.js
+++ b/packages/validate/__tests__/integration/validator/min.js
@@ -12,7 +12,7 @@ describe('Validate > Integration > validator > min', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState false for data-val min validator with value less than min', async () => {
@@ -27,7 +27,7 @@ describe('Validate > Integration > validator > min', () => {
 			type="number">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
     
 
@@ -41,7 +41,7 @@ describe('Validate > Integration > validator > min', () => {
 			type="number">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState false for data-val min validator with value greater than min', async () => {
@@ -56,7 +56,7 @@ describe('Validate > Integration > validator > min', () => {
 			type="number">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState false for data-val min validator with a non-numeric value', async () => {
@@ -71,7 +71,7 @@ describe('Validate > Integration > validator > min', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for unrequired HTML5 min validator with no value', async () => {
@@ -84,7 +84,7 @@ describe('Validate > Integration > validator > min', () => {
 			type="number">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for unrequired data-val min validator with no value', async () => {
@@ -99,7 +99,7 @@ describe('Validate > Integration > validator > min', () => {
 			type="number">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
 });

--- a/packages/validate/__tests__/integration/validator/minlength.js
+++ b/packages/validate/__tests__/integration/validator/minlength.js
@@ -14,7 +14,7 @@ describe('Validate > Integration > validator > minlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for data-val minlength validator with value length greater than the min', async () => {
@@ -29,7 +29,7 @@ describe('Validate > Integration > validator > minlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for unrequired data-val minlength validator with no value', async () => {
@@ -44,7 +44,7 @@ describe('Validate > Integration > validator > minlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState false for HTML5 minlength validator with value length less than min length', async () => {
@@ -57,7 +57,7 @@ describe('Validate > Integration > validator > minlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState false for HTML5 minlength validator with value length greater than min length', async () => {
@@ -70,7 +70,7 @@ describe('Validate > Integration > validator > minlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for unrequired HTML5 minlength validator with no value', async () => {
@@ -83,7 +83,7 @@ describe('Validate > Integration > validator > minlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
 });

--- a/packages/validate/__tests__/integration/validator/number.js
+++ b/packages/validate/__tests__/integration/validator/number.js
@@ -18,8 +18,8 @@ describe('Validate > Integration > validator > number', () => {
         const group1 = assembleValidationGroup({}, input1).group1;
         const input2 = document.querySelector('#group2');
         const group2 = assembleValidationGroup({}, input2).group2;
-        expect(validate(group1, group1.validators[0])).toEqual(true);
-        expect(validate(group2, group2.validators[0])).toEqual(true);
+        expect(await validate(group1, group1.validators[0])).toEqual(true);
+        expect(await validate(group2, group2.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for non-required empty HTML5 number validator field', async () => {
@@ -31,7 +31,7 @@ describe('Validate > Integration > validator > number', () => {
 			type="number">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState false for data-val number validator with non-number', async () => {
@@ -45,7 +45,7 @@ describe('Validate > Integration > validator > number', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for data-val number validator with a number', async () => {
@@ -67,8 +67,8 @@ describe('Validate > Integration > validator > number', () => {
         const group1 = assembleValidationGroup({}, input1).group1;
         const input2 = document.querySelector('#group2');
         const group2 = assembleValidationGroup({}, input2).group2;
-        expect(validate(group1, group1.validators[0])).toEqual(true);
-        expect(validate(group2, group2.validators[0])).toEqual(true);
+        expect(await validate(group1, group1.validators[0])).toEqual(true);
+        expect(await validate(group2, group2.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for non-required empty data-val number validator field', async () => {
@@ -82,7 +82,7 @@ describe('Validate > Integration > validator > number', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
 });

--- a/packages/validate/__tests__/integration/validator/range.js
+++ b/packages/validate/__tests__/integration/validator/range.js
@@ -15,7 +15,7 @@ describe('Validate > Integration > validator > range', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for data-val range validator with value inside the specified range', async () => {
@@ -31,7 +31,7 @@ describe('Validate > Integration > validator > range', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for an unrequired data-val range validator with no value', async () => {
@@ -47,7 +47,7 @@ describe('Validate > Integration > validator > range', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for data-val range validator with value > min with no max', async () => {
@@ -62,7 +62,7 @@ describe('Validate > Integration > validator > range', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState false for data-val range validator with value <= min with no max', async () => {
@@ -77,7 +77,7 @@ describe('Validate > Integration > validator > range', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for data-val range validator with value <= max with no min', async () => {
@@ -92,7 +92,7 @@ describe('Validate > Integration > validator > range', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState false for data-val range validator with value > max with no min', async () => {
@@ -107,7 +107,7 @@ describe('Validate > Integration > validator > range', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
 });

--- a/packages/validate/__tests__/integration/validator/regex-pattern.js
+++ b/packages/validate/__tests__/integration/validator/regex-pattern.js
@@ -11,7 +11,7 @@ describe('Validate > Integration > validator > regex/pattern', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
     
     it('should return the validityState false for HTML5 pattern validator with matching value', async () => {
@@ -24,7 +24,7 @@ describe('Validate > Integration > validator > regex/pattern', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for non-required empty HTML5 pattern validator field', async () => {
@@ -37,7 +37,7 @@ describe('Validate > Integration > validator > regex/pattern', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState false for data-val regex validator with non-matching value', async () => {
@@ -52,7 +52,7 @@ describe('Validate > Integration > validator > regex/pattern', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for data-val regex validator with a matching value', async () => {
@@ -67,7 +67,7 @@ describe('Validate > Integration > validator > regex/pattern', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for non-required empty data-val pattern validator field', async () => {
@@ -82,7 +82,7 @@ describe('Validate > Integration > validator > regex/pattern', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
 });

--- a/packages/validate/__tests__/integration/validator/required.js
+++ b/packages/validate/__tests__/integration/validator/required.js
@@ -33,7 +33,7 @@ describe('Validate > Integration > validator > required', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState false for HTML5 required validator with no value other than whitespace', async () => {
@@ -46,7 +46,7 @@ describe('Validate > Integration > validator > required', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for HTML5 required validator with a value', async () => {
@@ -59,7 +59,7 @@ describe('Validate > Integration > validator > required', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState false for data-val required validator with no value', async () => {
@@ -73,7 +73,7 @@ describe('Validate > Integration > validator > required', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState false for data-val required validator with no value but whitespace', async () => {
@@ -87,7 +87,7 @@ describe('Validate > Integration > validator > required', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for data-val required validator with a value', async () => {
@@ -101,6 +101,6 @@ describe('Validate > Integration > validator > required', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 });

--- a/packages/validate/__tests__/integration/validator/stringlength.js
+++ b/packages/validate/__tests__/integration/validator/stringlength.js
@@ -14,7 +14,7 @@ describe('Validate > Integration > validator > stringlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState true for non-required empty data-val stringlength validator field', async () => {
@@ -29,7 +29,7 @@ describe('Validate > Integration > validator > stringlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for data-val stringlength validator with value less than max length', async () => {
@@ -44,7 +44,7 @@ describe('Validate > Integration > validator > stringlength', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
 });

--- a/packages/validate/__tests__/integration/validator/url.js
+++ b/packages/validate/__tests__/integration/validator/url.js
@@ -12,7 +12,7 @@ describe('Validate > Integration > validator > url', () => {
 			type="url">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
 
     it('should return the validityState false for data-val url validator with non-spec url', async () => {
@@ -26,7 +26,7 @@ describe('Validate > Integration > validator > url', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(false);
+        expect(await validate(group, group.validators[0])).toEqual(false);
     });
     
     it('should return the validityState true for non-required empty HTML5 url validator field', async () => {
@@ -38,7 +38,7 @@ describe('Validate > Integration > validator > url', () => {
 			type="url">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState true for non-required empty data-val url validator field', async () => {
@@ -52,7 +52,7 @@ describe('Validate > Integration > validator > url', () => {
 			type="text">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
     it('should return the validityState false for HTML5 url validator with an on-spec url', async () => {
@@ -64,7 +64,7 @@ describe('Validate > Integration > validator > url', () => {
 			type="url">`;
         const input = document.querySelector('#group1');
         const group = assembleValidationGroup({}, input).group1;
-        expect(validate(group, group.validators[0])).toEqual(true);
+        expect(await validate(group, group.validators[0])).toEqual(true);
     });
 
 

--- a/packages/validate/src/lib/validator/index.js
+++ b/packages/validate/src/lib/validator/index.js
@@ -151,7 +151,7 @@ export const normaliseValidators = input => input.getAttribute('data-val') === '
  * @param group [Array] DOM nodes with the same name attribute
  * @param validator [String] The type of validator matching it to validation method function
  * 
- * @returns validityState [Boolean]
+ * @returns  validityState [Promise]
  * 
  */
 export const validate = (group, validator) => new Promise((resolve, reject) => {
@@ -289,7 +289,7 @@ export const getValidityState = groups => Promise.all(
  * 
  * @params groups [Object]
  * 
- * @return validation results [Promise] aggregated promise
+ * @return validation results [Promises] aggregated promise
  * 
  */
 export const getGroupValidityState = group => {

--- a/packages/validate/src/lib/validator/index.js
+++ b/packages/validate/src/lib/validator/index.js
@@ -154,19 +154,20 @@ export const normaliseValidators = input => input.getAttribute('data-val') === '
  * @returns validityState [Boolean]
  * 
  */
-export const validate = (group, validator) => {
+export const validate = (group, validator) => new Promise((resolve, reject) => {
     try {
-        return validator.type === 'custom'
-            ? methods.custom(validator.method, group)
-            : methods[validator.type](group, validator.params);
+        validator.type === 'custom'
+            ? resolve(methods.custom(validator.method, group))
+            : resolve(methods[validator.type](group, validator.params));
     } catch (err) {
         console.warn(err);
+        resolve(err);
     }
-};
+});
 
 /**
  * Reducer constructing an validation Object for a group of DOM nodes
- * 
+ *  
  * @param input [DOM node]
  * 
  * @returns validation object [Object] consisting of
@@ -292,25 +293,15 @@ export const getValidityState = groups => Promise.all(
  * 
  */
 export const getGroupValidityState = group => {
-    let hasError = false;
     //check if group is disabled
     if (groupIsDisabled(group.fields)) return Promise.resolve([true]);
     return Promise.all(group.validators.map(validator => new Promise((resolve, reject) => {
-        if (validator.type !== 'remote'){
-            if (validate(group, validator)) resolve(true);
-            else {
-                hasError = true;
-                resolve(false);
-            }
-        } else if (hasError) resolve(false);
-        else {
-            validate(group, validator)
-                .then(res => {
-                    if (res === 'true') resolve(true);
-                    if (res === 'false') resolve(false);
-                    resolve(res);
-                });
-        }
+        validate(group, validator)
+            .then(res => {
+                if (String(res) !== 'true') resolve(String(res) === 'false' ? false : res);
+                else resolve(true);
+            })
+            .catch(err => console.warn(err));
     })));
 };
 


### PR DESCRIPTION
Addresses #208 

- adds support for asynchronous custom validators
- makes all validation methods asynchronous so it simplifies the code a little (I think it can be improved even more, especially if we changed to async/await, but I think that's a separate issue across the whole codebase rather than in these couple of functions).
- adds a test or two, and updates a heap of tests that the change broke
