### PR TITLE
Update to ignore focus on blur if the focus target is a toggle

### DIFF
--- a/packages/toggle/src/lib/dom.js
+++ b/packages/toggle/src/lib/dom.js
@@ -151,7 +151,8 @@ const targetIsToggle = (toggles, target) => toggles.reduce((acc, toggle) => {
  * @param Event, event dispatched from document
  */
 export const focusInListener = Store => e => {
-    if (!Store.getState().node.contains(e.target)) toggle(Store)();
+    const state = Store.getState();
+    if (!state.node.contains(e.target) && !targetIsToggle(state.toggles, e.target)) toggle(Store)();
 };
 
 /*


### PR DESCRIPTION
Potential fix for #215 where the blur/focus behaviour is ignored if the focus target is a toggle.

Previous implementation was looking for the focus target to be inside the toggling node, which sometimes the toggle button wouldn't be.

Makes version 1.0.0-alpha.12+ compatible with the standard UI pattern