### PR TITLE
Adding focusOnLoad option

### DIFF
--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -60,6 +60,7 @@ const [ instance ] = tabs(elements);
     activeClass: 'is--active', //className added to active tab
     updateURL: true, //push tab fragment identifier to window location hash
     activeIndex: 0 //index of initially active tab
+    focusOnLoad: true //a boolean to set whether the page should focus on the first tab after loading
 }
 ```
 

--- a/packages/tabs/__tests__/unit/init.js
+++ b/packages/tabs/__tests__/unit/init.js
@@ -28,7 +28,6 @@ const init = () => {
     
 };
 
-
 describe(`Tabs > init`, () => {
     
     beforeAll(init);
@@ -94,6 +93,58 @@ describe(`Tabs > init`, () => {
         TabSet = tabs('[role=tablist]');
 
         expect(TabSet[0].getState().activeIndex).toEqual(1);
+    });
+
+    it('should set focus on first tab by default', () => {
+        document.body.innerHTML = `<div role="tablist" data-active-index="1">
+            <nav class="tabs__nav">
+                <a id="tab-1" class="tabs__nav-link js-tabs__link" href="#panel-1" role="tab">Tab 1</a>
+                <a id="tab-2" class="tabs__nav-link js-tabs__link" href="#panel-2" role="tab">Tab 2</a>
+                <a id="tab-3" class="tabs__nav-link js-tabs__link" href="#panel-3" role="tab">Tab 3</a>
+            </nav>
+            <section id="panel-1" class="tabs__section" role="tabpanel">Panel 1</section>
+            <section id="panel-2" class="tabs__section" role="tabpanel" hidden>
+                    <p>Panel 2</p>
+                    <p><a href="/">Test link</a></p>
+                    <p><a href="/">Test link</a></p>
+            </section>
+            <section id="panel-3" class="tabs__section" role="tabpanel" hidden>
+                <p>Panel 3</p>
+                <p><a href="/">Test link</a></p>
+                <p><a href="/">Test link</a></p>
+            </section>
+        </div>`;
+
+        TabSet = tabs('[role=tablist]');
+        setTimeout(() =>{
+            expect(document.activeElement.classList.contains('tabs__nav-link')).toBeTruthy();
+        }, 1);
+    });
+
+    it('should not set focus on first tab if focusOnLoad option is set to false', () => {
+        document.body.innerHTML = `<div role="tablist" data-active-index="1">
+            <nav class="tabs__nav">
+                <a id="tab-1" class="tabs__nav-link js-tabs__link" href="#panel-1" role="tab">Tab 1</a>
+                <a id="tab-2" class="tabs__nav-link js-tabs__link" href="#panel-2" role="tab">Tab 2</a>
+                <a id="tab-3" class="tabs__nav-link js-tabs__link" href="#panel-3" role="tab">Tab 3</a>
+            </nav>
+            <section id="panel-1" class="tabs__section" role="tabpanel">Panel 1</section>
+            <section id="panel-2" class="tabs__section" role="tabpanel" hidden>
+                    <p>Panel 2</p>
+                    <p><a href="/">Test link</a></p>
+                    <p><a href="/">Test link</a></p>
+            </section>
+            <section id="panel-3" class="tabs__section" role="tabpanel" hidden>
+                <p>Panel 3</p>
+                <p><a href="/">Test link</a></p>
+                <p><a href="/">Test link</a></p>
+            </section>
+        </div>`;
+
+        TabSet = tabs('[role=tablist]', {focusOnLoad: false});
+        setTimeout(() =>{
+            expect(document.activeElement.classList.contains('tabs__nav-link')).toBeFalsy();
+        }, 1);
     });
 
     it('should set activeIndex based on location hash', () => {

--- a/packages/tabs/src/lib/defaults.js
+++ b/packages/tabs/src/lib/defaults.js
@@ -9,11 +9,13 @@ import { MODES } from './constants';
  * @property activation, string, 'auto' or 'manual' describes tab activation method.  
  * as per https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-2/tabs.html or https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html
  * @property active, Number, index of initially active tab
+ * @property focusOnLoad, Boolean, sets whether the page should focus on the first tab on load
  */
 export default {
     tabSelector: '[role=tab]',
     activeClass: 'is--active',
     updateURL: true,
     activation: MODES.AUTO,
-    activeIndex: 0
+    activeIndex: 0,
+    focusOnLoad: true
 };

--- a/packages/tabs/src/lib/factory.js
+++ b/packages/tabs/src/lib/factory.js
@@ -19,8 +19,9 @@ export default ({ node, settings }) => {
         //activeTabIndex should initially match the active panel, so initialising here to the same value
         activeTabIndex: activeIndex !== undefined ? +activeIndex : +settings.activeIndex, 
         tabs,
-        panels
-    }, [ initUI(Store), open ]);
+        panels,
+        loaded: false
+    }, [ initUI(Store), open(Store) ]);
 
     return {
         getState: Store.getState


### PR DESCRIPTION
We were using the tabs script as part of a project to include tabbed content towards the bottom of the page design.

We were finding that the script was auto-focussing on the first tab on page load, which was pulling the keyboard focus to the wrong spot in the content as there was a lot of content above that was skipped.  The page was also visually being scrolled to the bottom so that the tabs were in view.

This PR potentially adds a 'focusOnLoad' option which defaults to true as per the current implementations, but gives the option to set to false if needed and avoid the auto-focus on page-load only.

Let me know what you think, or if you have any thoughts on other solutions!

Cheers,
S