### PR TITLE
Making the use of the hidden attribute optional

### DIFF
--- a/packages/toggle/__tests__/accessibility.js
+++ b/packages/toggle/__tests__/accessibility.js
@@ -19,7 +19,8 @@ const init = () => {
     Toggles = toggle('.js-toggle', {
         trapTab: true,
         closeOnBlur: true,
-        focus: true
+        focus: true,
+        useHidden: true
     });
     // TogglesLocal = toggle('.js-toggle-local', {
     //     local: true
@@ -45,7 +46,7 @@ describe(`Toggle > Accessibility`, () => {
         expect(document.activeElement.getAttribute('id')).toEqual('focusable-1-1');
     });
 
-    it('should change the add a hidden attribute on the node when clicked', async () => {
+    it('should change the hidden attribute on the node when clicked', async () => {
         Toggles[0].getState().toggles[0].click();
         expect(Toggles[0].getState().node.hidden).toBeFalsy();
     });

--- a/packages/toggle/example/src/js/index.js
+++ b/packages/toggle/example/src/js/index.js
@@ -4,7 +4,8 @@ window.addEventListener('DOMContentLoaded', () => {
     window.__t1__ = toggle('.js-toggle', {
         focus: false,
         closeOnClick: true,
-        closeOnBlur: true
+        closeOnBlur: true,
+        useHidden:true
     });
     // window.__t2__ = toggle('.js-toggle__local', {
     //     closeOnBlur: true

--- a/packages/toggle/src/lib/defaults.js
+++ b/packages/toggle/src/lib/defaults.js
@@ -11,6 +11,7 @@
  * @property trapTab, Boolean, the toggled element should trap tab (tabbing from last child item returns focus to the first) when open
  * @property closeOnBlur, Boolean, the toggled element should close when focus moves to a non-child element
  * @property closeOnClick, Boolean, the toggled element should close when a non-child element is clicked
+ * @property useHidden, Boolean, set to true to add the html 'hidden' attribute to the toggled element
  */
 export default {
     delay: 0,
@@ -21,5 +22,6 @@ export default {
     focus: true,
     trapTab: false,
     closeOnBlur: false,
-    closeOnClick: false
+    closeOnClick: false,
+    useHidden: false
 };

--- a/packages/toggle/src/lib/dom.js
+++ b/packages/toggle/src/lib/dom.js
@@ -6,8 +6,8 @@ import { FOCUSABLE_ELEMENTS, ACCEPTED_TRIGGERS, EVENTS } from './constants';
  * @param Store, Object, model or state of the current instance
  */
 export const initUI = Store => () => {
-    const { toggles, node } = Store.getState();
-    node.hidden = true;
+    const { toggles, node, settings } = Store.getState();
+    if(settings.useHidden) node.hidden = true;
     toggles.forEach(toggle => {
         const id = node.getAttribute('id');
         if (toggle.tagName !== 'BUTTON') toggle.setAttribute('role', 'button');
@@ -82,11 +82,11 @@ export const getFocusableChildren = node => [].slice.call(node.querySelectorAll(
  * 
  * @param props, Object, composed of properties of current state required to accessibly change node toggles attributes
  */
-export const toggleAttributes = ({ toggles, isOpen, node, classTarget, animatingClass, statusClass }) => {
+export const toggleAttributes = ({ toggles, isOpen, node, classTarget, animatingClass, statusClass, settings }) => {
     toggles.forEach(toggle => toggle.setAttribute('aria-expanded', isOpen));
     classTarget.classList.remove(animatingClass);
     classTarget.classList[isOpen ? 'add' : 'remove'](statusClass);
-    node.hidden = !isOpen;
+    if(settings.useHidden) node.hidden = !isOpen;
 };
 
 /*


### PR DESCRIPTION
Makes the use of the hidden attribute optional by adding a 'useHidden' setting.  Defaults to 'false' for backwards compatibility.