### PR TITLE
Initialising form after banner is shown manually

### DIFF
--- a/packages/cookie-banner/src/lib/ui.js
+++ b/packages/cookie-banner/src/lib/ui.js
@@ -18,7 +18,7 @@ export const showBanner = Store => cb => {
     initBanner(Store)();
     const { bannerOpen } = Store.getState();
     if (!bannerOpen) return;
-    initForm(Store);
+    initForm(Store)();
     const focusableChildren = getFocusableChildren(document.body.firstElementChild);
     if (focusableChildren.length > 0) focusableChildren[0].focus();
     if (cb && cb.call) cb(Store.getState());

--- a/packages/cookie-banner/src/lib/ui.js
+++ b/packages/cookie-banner/src/lib/ui.js
@@ -18,6 +18,7 @@ export const showBanner = Store => cb => {
     initBanner(Store)();
     const { bannerOpen } = Store.getState();
     if (!bannerOpen) return;
+    initForm(Store);
     const focusableChildren = getFocusableChildren(document.body.firstElementChild);
     if (focusableChildren.length > 0) focusableChildren[0].focus();
     if (cb && cb.call) cb(Store.getState());


### PR DESCRIPTION
I was implementing a cookie banner this morning which used the pattern suggestion from the library that has the form within the banner.

I was also hoping to use the new showBanner method to bring the banner back up from an iframe placeholder, but found that the showBanner method wasn't displaying the form in the same way that the main init function was.

Is this OK to add as per the PR?

Cheers,
S