### PR TITLE
Add events to cookie banner

### DIFF
--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -169,7 +169,7 @@ There are three custom events that an instance of the cookie banner dispatches:
 - `banner.hide` when it is hidden
 - `banner.consent` when consent is ste or updated
 
-The events are dispatched on the document. Areference to the getState function of the instance is contained in the custom event detail.
+The events are dispatched on the document. A reference to the getState function of the instance is contained in the custom event detail.
 
 ```
 const instance = banner(options);

--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -162,6 +162,27 @@ The Object returned from initialisation exposes the interface
 }
 ```
 
+## Events
+
+There are three custom events that an instance of the cookie banner dispatches:
+- `banner.show` when the banner is displayed
+- `banner.hide` when it is hidden
+- `banner.consent` when consent is ste or updated
+
+The events are dispatched on the document. Areference to the getState function of the instance is contained in the custom event detail.
+
+```
+const instance = banner(options);
+
+document.addEventListener('banner.show', e => {
+    //e.g. initialise toggle for form-in-banner implementation
+    const [ bannerToggle ] = toggle('.js-banner-toggle'); 
+    const state = e.detail.getState();
+    // do something with state if we want to
+});
+
+```
+
 ## Tests
 ```
 npm t

--- a/packages/cookie-banner/__tests__/utils.js
+++ b/packages/cookie-banner/__tests__/utils.js
@@ -1,5 +1,7 @@
-import { groupValueReducer, removeSubdomain, extractFromCookie } from '../src/lib/utils';
+import { groupValueReducer, removeSubdomain, extractFromCookie, broadcast } from '../src/lib/utils';
 import defaults from '../src/lib/defaults';
+import { EVENTS } from '../src/lib/constants';
+import { createStore } from '../src/lib/store';
 
 describe('Cookie > Utils > removeSubdomain', () => {
     it('should return the same vaule for a root domain', async () => {
@@ -124,6 +126,28 @@ describe('Cookie > Utils > extractFromCookie > cookie not base64 encoded', () =>
         expect(hasCookie).toEqual(false);
         expect(cid).toBeDefined();
         expect(consent).toEqual({});
+    });
+
+});
+
+describe(`Cookie banner > Utils > broadcast`, () => {
+
+    it('should dispatch a custom event with a detail Object with a reference to Store.getState', async () => {
+        const Store = createStore();
+        const state = {
+            consent: {},
+            bannerOpen: true,
+            settings: defaults
+        };
+        Store.update(_ => _, state);
+        const listener = jest.fn();
+        document.addEventListener(EVENTS.OPEN, listener);
+        document.addEventListener(EVENTS.OPEN, e => {
+            expect(e.detail).toEqual({ getState: Store.getState });
+        });
+
+        broadcast(EVENTS.OPEN, Store)(state);
+        expect(listener).toHaveBeenCalled();
     });
 
 });

--- a/packages/cookie-banner/src/lib/constants.js
+++ b/packages/cookie-banner/src/lib/constants.js
@@ -33,3 +33,9 @@ export const MEASUREMENTS = {
         ea: 'CookiePrefs'
     }
 };
+
+export const EVENTS = {
+    SHOW: 'banner.show',
+    HIDE: 'banner.hide',
+    CONSENT: 'banner.consent'
+};

--- a/packages/cookie-banner/src/lib/ui.js
+++ b/packages/cookie-banner/src/lib/ui.js
@@ -1,5 +1,5 @@
-import { writeCookie, groupValueReducer, deleteCookies, getFocusableChildren } from './utils';
-import { ACCEPTED_TRIGGERS, MEASUREMENTS } from './constants';
+import { writeCookie, groupValueReducer, deleteCookies, getFocusableChildren, broadcast } from './utils';
+import { ACCEPTED_TRIGGERS, MEASUREMENTS, EVENTS } from './constants';
 import { apply } from './consent';
 import { updateConsent, updateBannerOpen } from './reducers';
 import { measure, composeMeasurementConsent } from './measurement';
@@ -11,7 +11,7 @@ export const initBanner = Store => () => {
     //track banner display
     if (state.settings.tid) measure(state, MEASUREMENTS.BANNER_DISPLAY);
     
-    Store.update(updateBannerOpen, true);
+    Store.update(updateBannerOpen, true, [ broadcast(EVENTS.SHOW, Store) ]);
 };
 
 export const showBanner = Store => cb => {
@@ -48,6 +48,7 @@ export const initBannerListeners = Store => () => {
                         apply(Store),
                         removeBanner(Store, banner),
                         initForm(Store, false),
+                        broadcast(EVENTS.CONSENT, Store),
                         //track banner accept click
                         state => {
                             if (state.settings.tid) {
@@ -77,7 +78,7 @@ export const initBannerListeners = Store => () => {
 const removeBanner = (Store, banner) => () => {
     if (banner && banner.parentNode) {
         banner.parentNode.removeChild(banner);
-        Store.update(updateBannerOpen, false);
+        Store.update(updateBannerOpen, false, [ broadcast(EVENTS.HIDE, Store) ]);
     }
 };
 
@@ -134,6 +135,7 @@ export const initForm = (Store, track = true) => () => {
                 writeCookie,
                 apply(Store),
                 removeBanner(Store, banner),
+                broadcast(EVENTS.CONSENT, Store),
                 renderMessage(button),
                 state => {
                     if (!state.settings.tid) return;

--- a/packages/cookie-banner/src/lib/utils.js
+++ b/packages/cookie-banner/src/lib/utils.js
@@ -1,4 +1,4 @@
-import { FOCUSABLE_ELEMENTS } from './constants';
+import { FOCUSABLE_ELEMENTS, EVENTS } from './constants';
 
 //Modernizr cookie test
 export const cookiesEnabled = () => {
@@ -114,3 +114,13 @@ export const uuidv4 = () => 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]
 });
 
 export const getFocusableChildren = node => [].slice.call(node.querySelectorAll(FOCUSABLE_ELEMENTS.join(',')));
+
+export const broadcast = (type, Store) => state => {
+    const event = new CustomEvent(type, {
+        bubbles: true,
+        detail: {
+            getState: Store.getState
+        }
+    });
+    window.document.dispatchEvent(event);
+};


### PR DESCRIPTION
For #222 

Adds a custom event dispatcher for three events: `banner.show`, `banner.hide`, and `banner.consent` to simplify integration with the toggle component with the banner for our form-in-banner pattern. (It also offers opportunities to de-couple consent-based code from the banner config if we ever needed or wanted to).

Currently in our form-in-cookie banner code we we have to pass a callback to the showBanner function to initialise the toggle in the banner, and there isn't a simple way to clean up the className from the toggle after the banner is dismissed.

Something like
```
//initialise banner
const banner = cookieBanner(config);

//callback to be passed into show banner
const callback = () => {
    //check for banner toggle className and reset if it is present (if a user has previously opened the banner and changed preferences)
    //we need either this line to remove the className, just leave it hanging around, or add something like a mutatioobserver to do the clean up when the banner is dismissed
    if (document.documentElement.classList.contains('on--preferences-banner')) document.documentElement.classList.remove('on--preferences-banner');
    toggle('.js-banner-toggle');
};

//add banner trigger listeners passing callback 
[].slice.call(document.querySelector('.js-banner-trigger')).forEach(btn => btn.addEventListener('click', _ => banner.showBanner(callback)));
```


Adding the events means that you can do this without the callback and have improved control over toggle className:
```
//set up banner toggle based on events
let bannerToggle;
document.addEventListener('banner.show', _ => [ bannerToggle ] = toggle('.js-banner-toggle'));
// use an event handler to clean up className on root element if form in banner was open
document.addEventListener('banner.hide', _ => bannerToggle.startToggle());

//initialise banner
const banner = cookieBanner(config);
//add banner trigger listeners
[].slice.call(document.querySelectorAll('.js-banner-trigger')).forEach(btn => btn.addEventListener('click', _ => banner.showBanner()));
```

or, if we want the toggle open when we re-trigger the banner:
```
let bannerToggle;
document.addEventListener('banner.show', _ => [ bannerToggle ] = toggle('.js-banner-toggle'));
document.addEventListener('banner.hide', _ => bannerToggle.startToggle());

const banner = cookieBanner(config);
[].slice.call(document.querySelectorAll('.js-banner-trigger')).forEach(btn => btn.addEventListener('click', _ => {
    banner.showBanner();
    bannerToggle.startToggle();
}));
```

if we don't mind the toggle className hanging around, it's still a bit easier to understand without the callback (imo)
```
document.addEventListener('banner.show', _ => toggle('.js-banner-toggle'));
const banner = cookieBanner(config);
[].slice.call(document.querySelectorAll('.js-banner-trigger')).forEach(btn => btn.addEventListener('click', _ => banner.showBanner()));
```

We could add more events in the future for stuff like form rendering, form submission that may be handy for accessibility (thinking announcements).
