### PR TITLE
Feature/224

### DIFF
--- a/docs/cookie-banner.html
+++ b/docs/cookie-banner.html
@@ -339,6 +339,24 @@ const cookieBanner = banner({
     renderForm, Function to render the consent form
 }
 </code></pre>
+<h2 id="events">Events</h2>
+<p>There are three custom events that an instance of the cookie banner dispatches:</p>
+<ul>
+<li><code>banner.show</code> when the banner is displayed</li>
+<li><code>banner.hide</code> when it is hidden</li>
+<li><code>banner.consent</code> when consent is set or updated</li>
+</ul>
+<p>The events are dispatched on the document. A reference to the getState function of the instance is contained in the custom event detail.</p>
+<pre><code>const instance = banner(options);
+
+document.addEventListener('banner.show', e =&gt; {
+    //e.g. initialise toggle for form-in-banner implementation
+    const [ bannerToggle ] = toggle('.js-banner-toggle'); 
+    const state = e.detail.getState();
+    // do something with state if we want to
+});
+
+</code></pre>
 <h2 id="tests">Tests</h2>
 <pre><code>npm t
 </code></pre>

--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -15,6 +15,8 @@ The cookie banner renders itself if no consent preferences are recorded in the b
 
 The consent form renders into a DOMElement with a particular className configurable options (classNames.formContainer).
 
+A page containing a cookie consent form should include a visually hidden live region (role=alert) with a particular className (classNames.formAnnouncement), default: 'privacy-banner__form-announcement'.
+
 
 Install the package
 ```
@@ -87,6 +89,7 @@ const cookieBanner = banner({
         legend: 'privacy-banner__legend',
         formContainer: 'privacy-banner__form-container', //where the form is rendered
         formMessage: 'privacy-banner__form-msg',
+        formAnnouncement: 'privacy-banner__form-announcement', //screen reader announcement
         title: 'privacy-banner__form-title',
         description: 'privacy-banner__form-description'
     },

--- a/packages/cookie-banner/example/src/index.html
+++ b/packages/cookie-banner/example/src/index.html
@@ -92,7 +92,7 @@
                 <p>Cookies are a common feature used on almost all websites. A cookie is a small text file that is downloaded onto a device to allow a website to recognise it and to store some information about your preferences.</p>
                 <p>We use cookies for different reasons, including for managing your shopping cart, measuring your visits on our sites, recognising and remembering your preferences and showing you personalised ads. Learn more about cookies and how we use them.</p>
                 <div class="privacy-banner__form-container"></div>
-                <div class="privacy-banner__form-message" style="position: absolute;width:1px;height:1px;opacity:0;" role="alert"></div>
+                <div class="privacy-banner__form-announcement" style="position: absolute;width:1px;height:1px;opacity:0;" role="alert"></div>
 
 
             </div>

--- a/packages/cookie-banner/example/src/index.html
+++ b/packages/cookie-banner/example/src/index.html
@@ -70,20 +70,32 @@
         .privacy-banner__btn:hover {
             background-color: blue
         }
+        .privacy-banner__form-announcement {
+            position: absolute;
+            opacity: 0;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0 0 0 0);
+            border: 0;
+        }
     </style>
   </head>
   <body>
       <button class="js-open-banner">Open banner</button>
-    <div class="container">
-        <div class="privacy-banner__update"></div>
-        <div class="">
-            <h1>Cookies</h1>
-            <p>Cookies are a common feature used on almost all websites. A cookie is a small text file that is downloaded onto a device to allow a website to recognise it and to store some information about your preferences.</p>
-            <p>We use cookies for different reasons, including for managing your shopping cart, measuring your visits on our sites, recognising and remembering your preferences and showing you personalised ads. Learn more about cookies and how we use them.</p>
-            <div class="privacy-banner__form-container"></div>
+        <div class="container">
+            <div class="privacy-banner__update"></div>
+            <div class="">
+                <h1>Cookies</h1>
+                <p>Cookies are a common feature used on almost all websites. A cookie is a small text file that is downloaded onto a device to allow a website to recognise it and to store some information about your preferences.</p>
+                <p>We use cookies for different reasons, including for managing your shopping cart, measuring your visits on our sites, recognising and remembering your preferences and showing you personalised ads. Learn more about cookies and how we use them.</p>
+                <div class="privacy-banner__form-container"></div>
+                <div class="privacy-banner__form-message" style="position: absolute;width:1px;height:1px;opacity:0;" role="alert"></div>
 
 
+            </div>
         </div>
-    </div>
   </body>
 </html>

--- a/packages/cookie-banner/src/lib/defaults.js
+++ b/packages/cookie-banner/src/lib/defaults.js
@@ -22,6 +22,7 @@ export default {
         legend: 'privacy-banner__legend',
         formContainer: 'privacy-banner__form-container',
         formMessage: 'privacy-banner__form-msg',
+        formAnnouncement: 'privacy-banner__form-announcement',
         title: 'privacy-banner__form-title',
         description: 'privacy-banner__form-description'
     },
@@ -43,7 +44,7 @@ export default {
         </section>`;
     },
     messageTemplate(model){
-        return `<div class="${model.settings.classNames.formMessage}" aria-role="alert">${model.settings.savedMessage}</div>`;
+        return `<div class="${model.settings.classNames.formMessage}" aria-hidden="true">${model.settings.savedMessage}</div>`;
     },
     formTemplate(model){
         return `<form id="preferences" class="${model.settings.classNames.form}" novalidate>

--- a/packages/cookie-banner/src/lib/ui.js
+++ b/packages/cookie-banner/src/lib/ui.js
@@ -29,13 +29,13 @@ export const initBannerListeners = Store => () => {
     const banner = document.querySelector(`.${state.settings.classNames.banner}`);
     if (!banner) return;
 
-    const composeSelector = classSelector => { return ACCEPTED_TRIGGERS.map(sel => `${sel}.${classSelector}`).join(", "); }
+    const composeSelector = classSelector => ACCEPTED_TRIGGERS.map(sel => `${sel}.${classSelector}`).join(', ');
 
     const acceptBtns = [].slice.call(document.querySelectorAll(composeSelector(state.settings.classNames.acceptBtn)));
-    const optionsBtn = document.querySelector(composeSelector(state.settings.classNames.optionsBtn)); 
+    const optionsBtn = document.querySelector(composeSelector(state.settings.classNames.optionsBtn));
 
-    acceptBtns.forEach(acceptBtn => {  
-        if(acceptBtns) {
+    acceptBtns.forEach(acceptBtn => {
+        if (acceptBtns) {
             acceptBtn.addEventListener('click', e => {
                 Store.update(
                     updateConsent,
@@ -63,7 +63,7 @@ export const initBannerListeners = Store => () => {
             });
         } else {
             console.warn('Banner accept element must be a Button or Anchor.  No trigger event added.');
-        }   
+        }
     });
 
     //track options click
@@ -111,6 +111,9 @@ export const initForm = (Store, track = true) => () => {
         else groups[groupName] = [field];
         return groups;
     }, {});
+    const formAnnouncement = document.querySelector(`.${state.settings.classNames.formAnnouncement}`)
+                            || document.body.appendChild(Object.assign(document.createElement('div'), { className: state.settings.classNames.formAnnouncement, role: 'alert' }));
+
 
     const extractConsent = () => Object.keys(groups).reduce((acc, key) => {
         const value = groups[key].reduce(groupValueReducer, '');
@@ -137,6 +140,7 @@ export const initForm = (Store, track = true) => () => {
                 removeBanner(Store, banner),
                 broadcast(EVENTS.CONSENT, Store),
                 renderMessage(button),
+                renderAnnoucement(formAnnouncement),
                 state => {
                     if (!state.settings.tid) return;
                     const consentString = composeMeasurementConsent(state.consent);
@@ -165,4 +169,8 @@ export const renderMessage = button => state => {
         button.parentNode.removeChild(button.nextElementSibling);
         button.removeAttribute('disabled');
     }, 3000);
+};
+
+export const renderAnnoucement = container => state => {
+    container.textContent = state.settings.savedMessage;
 };

--- a/packages/cookie-banner/src/lib/ui.js
+++ b/packages/cookie-banner/src/lib/ui.js
@@ -140,7 +140,7 @@ export const initForm = (Store, track = true) => () => {
                 removeBanner(Store, banner),
                 broadcast(EVENTS.CONSENT, Store),
                 renderMessage(button),
-                renderAnnoucement(formAnnouncement),
+                renderAnnouncement(formAnnouncement),
                 state => {
                     if (!state.settings.tid) return;
                     const consentString = composeMeasurementConsent(state.consent);
@@ -171,6 +171,10 @@ export const renderMessage = button => state => {
     }, 3000);
 };
 
-export const renderAnnoucement = container => state => {
+export const renderAnnouncement = container => state => {
     container.textContent = state.settings.savedMessage;
+    /* istanbul ignore next */
+    window.setTimeout(() => {
+        container.textContent = '';
+    }, 3000);
 };


### PR DESCRIPTION
Fixes #224 

Adds support for a visually hidden live region to announce consent preference form submission.

Test case at https://storm-ui-patterns.netlify.app/example/cookie-banner/form/