### PR TITLE
Feature/229

### DIFF
--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -49,9 +49,10 @@ const cookieBanner = banner({
                 no: 'Pages you visit and actions you take will not be measured and used to improve the service'
             },
             fns: [
-                model => { 
+                state => { 
                     //function that depends upon or creates a 'performance' cookie
-                }
+                },
+                state => state.utils.gtmSnippet(<UA-CODE>)
             ]
         },
         'thirdParty': {
@@ -64,7 +65,9 @@ const cookieBanner = banner({
             fns: [
                 model => { 
                     //function that depends upon or creates a 'performance' cookie
-                }
+                },
+                state => state.utils.renderIframe(),
+                state => state.utils.gtmSnippet(<UA-CODE>)
             ]
         }
     }
@@ -159,6 +162,53 @@ const cookieBanner = banner({
     }
 }
 ```
+
+## Utility functions
+There are two utility functions provided by the library designed to be invoked following user consent.
+
+### Render iFrame
+`state.utils.renderIframe`
+
+Renders an iFrame from a placeholder element with specific data attributes:
+
+```
+<div data-iframe-src="https://www.youtube.com/embed/qpLKTUQev30" data-iframe-title="Test video" data-iframe-height="1600px" data-iframe-width="900px">
+    <button class="js-preferences-update">Update your cookie preferemces to view this content.</button>
+</div>
+```
+In the cookie banner configuration:
+```
+import cookieBanner from '@stormid/cookie-banner';
+
+cookieBanner({
+    ...lots of other config
+    type: {
+        thirdParty: [
+            state => state.utils.renderIframe()
+        ]
+    }
+})
+```
+
+### Google Tag Manager Snippet
+`state.utils.gtmSnippet`
+
+Invokes a GTM snippet to load the GTM library via an script element, just pass the Tag Manager ID/UA number an argument
+
+In the cookie banner configuration:
+```
+import cookieBanner from '@stormid/cookie-banner';
+
+cookieBanner({
+    ...lots of other config
+    type: {
+        thirdParty: [
+            state => state.utils.gtmSnippet(`UA-1234-5678`)
+        ]
+    }
+})
+```
+
 
 ## API
 The Object returned from initialisation exposes the interface

--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -173,7 +173,8 @@ Renders an iFrame from a placeholder element with specific data attributes:
 
 ```
 <div data-iframe-src="https://www.youtube.com/embed/qpLKTUQev30" data-iframe-title="Test video" data-iframe-height="1600px" data-iframe-width="900px">
-    <button class="js-preferences-update">Update your cookie preferemces to view this content.</button>
+    <p>Update your cookie preferences to view this content</p>
+    <button class="js-preferences-update">Update</button>
 </div>
 ```
 In the cookie banner configuration:

--- a/packages/cookie-banner/__tests__/utils.js
+++ b/packages/cookie-banner/__tests__/utils.js
@@ -1,4 +1,4 @@
-import { groupValueReducer, removeSubdomain, extractFromCookie, broadcast } from '../src/lib/utils';
+import { groupValueReducer, removeSubdomain, extractFromCookie, broadcast, renderIframe, gtmSnippet } from '../src/lib/utils';
 import defaults from '../src/lib/defaults';
 import { EVENTS } from '../src/lib/constants';
 import { createStore } from '../src/lib/store';
@@ -148,6 +148,41 @@ describe(`Cookie banner > Utils > broadcast`, () => {
 
         broadcast(EVENTS.OPEN, Store)(state);
         expect(listener).toHaveBeenCalled();
+    });
+
+});
+
+describe(`Cookie banner > Utils > renderIframe`, () => {
+
+    it('should render an iframe to an element based on data attributes', async () => {
+        const SRC = 'https://www.youtube.com/embed/qpLKTUQev30';
+        const TITLE = 'Test video';
+        const HEIGHT = `500px`;
+        const WIDTH = `500px`;
+        document.body.innerHTML = `<div
+            data-iframe-src="${SRC}"
+            data-iframe-title="${TITLE}"
+            data-iframe-height="${HEIGHT}"
+            data-iframe-width="${WIDTH}"
+             />`;
+        renderIframe();
+        const iframe = document.querySelector('iframe');
+        expect(iframe.getAttribute('src')).toEqual(SRC);
+        expect(iframe.getAttribute('title')).toEqual(TITLE);
+        expect(iframe.style.height).toEqual(HEIGHT);
+        expect(iframe.style.width).toEqual(WIDTH);
+    });
+
+});
+
+describe(`Cookie banner > Utils > gtmSnippet`, () => {
+
+    it('should render a Google Tag Manager script tag', async () => {
+        document.body.innerHTML = `<script></script>`; //gtm snippet needs a script already on the page to insertBefore
+        gtmSnippet('ua-1234-5678');
+        const gtmScript = document.querySelector('script');
+        expect(gtmScript).toBeDefined();
+        expect(gtmScript.src).toEqual('https://www.googletagmanager.com/gtm.js?id=ua-1234-5678');
     });
 
 });

--- a/packages/cookie-banner/example/src/index.html
+++ b/packages/cookie-banner/example/src/index.html
@@ -84,6 +84,7 @@
     </style>
   </head>
   <body>
+        <div class="embed"><div class="embed__placeholder" data-iframe-src="https://www.youtube.com/embed/qpLKTUQev30" data-iframe-title="test video"><p>Update your cookie preferences to view this content.</p><button type="button" class="embed__placeholder-btn js-preferences-update">Update preferences</button></div></div>
       <button class="js-open-banner">Open banner</button>
         <div class="container">
             <div class="privacy-banner__update"></div>

--- a/packages/cookie-banner/example/src/js/index.js
+++ b/packages/cookie-banner/example/src/js/index.js
@@ -1,4 +1,5 @@
-import cookieBanner from '../../../src';
+import cookieBanner from '../../../dist';
+
 const writeCookie = state => {
     document.cookie = [
         `${state.settings.name}=${btoa(JSON.stringify(state))};`,
@@ -15,16 +16,17 @@ window.addEventListener('DOMContentLoaded', () => {
         tid: 'UA-401849-33',
         secure: false,
         hideBannerOnFormPage: false,
-        necessary: [ () => {
-            // console.log('Necessary fn');
-            writeCookie({
-                settings: {
-                    name: '.Test.NecessaryCookie',
-                    expiry: 3
-                },
-                consent: '666',
-            });
-        } ],
+        necessary: [
+            () => {
+                writeCookie({
+                    settings: {
+                        name: '.Test.NecessaryCookie',
+                        expiry: 3
+                    },
+                    consent: '666',
+                });
+            }
+        ],
         types: {
             performance: {
                 suggested: 1,
@@ -44,7 +46,9 @@ window.addEventListener('DOMContentLoaded', () => {
                             },
                             consent: '666',
                         });
-                    }
+                    },
+                    state => state.utils.renderIframe(),
+                    state => state.utils.gtmSnippet('12345666')
                 ]
             },
             ads: {

--- a/packages/cookie-banner/src/lib/factory.js
+++ b/packages/cookie-banner/src/lib/factory.js
@@ -1,10 +1,9 @@
-import { cookiesEnabled, extractFromCookie, noop } from './utils';
+import { cookiesEnabled, extractFromCookie, noop, renderIframe, gtmSnippet } from './utils';
 import { showBanner, initBanner, initForm, initBannerListeners } from './ui';
 import { necessary, apply } from './consent';
 import { createStore } from './store';
 import { initialState } from './reducers';
 import { composeParams } from './measurement';
-import { renderIframe, gaSnippet } from './utils';
 
 export default settings => {
     /* istanbul ignore next */
@@ -25,7 +24,7 @@ export default settings => {
             bannerOpen: false,
             persistentMeasurementParams: settings.tid ? composeParams(cid, settings.tid) : false,
             consent,
-            utils: { renderIframe, gaSnippet }
+            utils: { renderIframe, gtmSnippet }
         },
         [
             necessary,

--- a/packages/cookie-banner/src/lib/factory.js
+++ b/packages/cookie-banner/src/lib/factory.js
@@ -4,6 +4,7 @@ import { necessary, apply } from './consent';
 import { createStore } from './store';
 import { initialState } from './reducers';
 import { composeParams } from './measurement';
+import { renderIframe, gaSnippet } from './utils';
 
 export default settings => {
     /* istanbul ignore next */
@@ -23,7 +24,8 @@ export default settings => {
             settings,
             bannerOpen: false,
             persistentMeasurementParams: settings.tid ? composeParams(cid, settings.tid) : false,
-            consent
+            consent,
+            utils: { renderIframe, gaSnippet }
         },
         [
             necessary,

--- a/packages/cookie-banner/src/lib/utils.js
+++ b/packages/cookie-banner/src/lib/utils.js
@@ -1,4 +1,4 @@
-import { FOCUSABLE_ELEMENTS, EVENTS } from './constants';
+import { FOCUSABLE_ELEMENTS } from './constants';
 
 //Modernizr cookie test
 export const cookiesEnabled = () => {
@@ -123,4 +123,33 @@ export const broadcast = (type, Store) => () => {
         }
     });
     window.document.dispatchEvent(event);
+};
+
+export const renderIframe = () => {
+    [].slice.call(document.querySelectorAll('[data-iframe-src]')).forEach(node => {
+        const iframe = document.createElement('iframe');
+        iframe.src = node.getAttribute('data-iframe-src');
+        if (node.hasAttribute('data-iframe-height')) iframe.style.height = node.getAttribute('data-iframe-height');
+        iframe.setAttribute('title', node.getAttribute('data-iframe-title') || 'iFrame embed');
+        if (node.hasAttribute('data-iframe-width')) iframe.style.width =  node.getAttribute('data-iframe-width' || '100%');
+        iframe.setAttribute('tabindex', '0');
+        iframe.setAttribute('frameborder', '0');
+        iframe.setAttribute('webkitallowfullscreen', 'webkitallowfullscreen');
+        iframe.setAttribute('mozallowfullscreen', 'mozallowfullscreen');
+        iframe.setAttribute('allowfullscreen', 'allowfullscreen');
+        node.parentNode.appendChild(iframe);
+        node.parentNode.removeChild(node);
+    });
+};
+
+export const gtmSnippet = id => {
+    !function(e, t, c, n, w, o) {
+        e[n] = e[n] || [], e[n].push({
+            "gtm.start": (new Date).getTime(),
+            event: "gtm.js"
+        });
+        var r = t.getElementsByTagName(c)[0], 
+            s = t.createElement(c);
+        s.async = !0, s.src = 'https://www.googletagmanager.com/gtm.js?id=' + w, r.parentNode.insertBefore(s, r)
+    }(window, document, "script", "dataLayer", id);
 };


### PR DESCRIPTION
Fixes #229

This update adds two utility functions renderIFrame and gtmSnippet, assigns them to the state Object so they are available to use in consent-triggered functions. More details in the associated issue.

I've added a couple of tests and updated the docs.