### PR TITLE
#245 Gallery returns an Object not an iterable Array

### DIFF
--- a/docs/modal-gallery.html
+++ b/docs/modal-gallery.html
@@ -215,7 +215,7 @@
 <p>Initialise the module</p>
 <pre><code>import modalGallery from '@stormid/modal-gallery';
 
-const [ gallery ] = modalGallery('.js-modal-gallery');
+const gallery = modalGallery('.js-modal-gallery');
 </code></pre>
 <p>Example MVP CSS</p>
 <pre><code>.modal-gallery__outer {
@@ -294,7 +294,7 @@ const [ gallery ] = modalGallery('.js-modal-gallery');
 <p>To create from a JavaScript Object</p>
 <pre><code>import modalGallery from '@stormid/modal-gallery';
 
-const [ gallery ] = modalGallery([
+const gallery = modalGallery([
     {
         src: '//placehold.it/500x500',
         srcset:'//placehold.it/800x800 800w, //placehold.it/500x500 320w',
@@ -310,7 +310,7 @@ const [ gallery ] = modalGallery([
 ]);
 
 //e.g. Open the gallery at the second item (index 1) by clicking on a button with the className 'js-modal-gallery__trigger'
-document.querySelector('.js-modal-gallery__trigger').addEventListener('click', () =&gt; gallery.open(1));
+if( gallery ) document.querySelector('.js-modal-gallery__trigger').addEventListener('click', () =&gt; gallery.open(1));
 </code></pre>
 <h2 id="options">Options</h2>
 <pre><code>{


### PR DESCRIPTION
Discovered whilst using the component that the docs implicitly suggest the returned gallery is an Array, whereas it is an Object.
This causes errors:
 - Runtime error as cannot iterate over the returned Object
 - Cannot access [gallery] or gallery[0] as both are undefined
 Example code updated to show correct usage (per my implimentation)
 
Also noted that adding the trigger method ought to be protected by a check to see if a gallery exists, otherwise we have a breaking runtime error - can't add a lister to a null object.
Added defensive conditional to example code.

 