### PR TITLE
Addition of date past/future plugins

### DIFF
--- a/docs/validate.html
+++ b/docs/validate.html
@@ -279,6 +279,8 @@ const [ validator ] = validate(elements);
 <li><a href="#plugins">Plugins</a>
 <ul>
 <li><a href="#isvaliddate">isValidDate</a></li>
+<li><a href="#isDateInFuture">isDateInFuture</a></li>
+<li><a href="#isDateInPast">isDateInPast</a></li>
 </ul>
 </li>
 <li><a href="#tests">Tests</a></li>
@@ -518,6 +520,10 @@ validator.removeGroup('new-fields');
 <h3 id="isvaliddate">isValidDate</h3>
 <p>Validate three separate day/month/year fields (similar to the govuk design system date component) as a single valid date.</p>
 <p>The minimum accepted year value in the isValidDate plugin is 1000. To set a different (more recent) minimum value consider using the <a href="#min">min</a> validator on the year input.</p>
+<h3 id="isDateInFuture">isDateInFuture</h3>
+<p>Validate three separate day/month/year fields (similar to the govuk design system date component) as a single date in the future.</p>
+<h3 id="isDateInPast">isDateInPast</h3>
+<p>Validate three separate day/month/year fields (similar to the govuk design system date component) as a single date in the past. (Today's date is valid)</p>
 <p>HTML</p>
 <pre><code>&lt;fieldset&gt;
     &lt;legend&gt;
@@ -536,13 +542,27 @@ validator.removeGroup('new-fields');
 </code></pre>
 <p>JS</p>
 <pre><code>import validate from '@stormid/validate';
-import { isValidDate } from '@stormid/validate/src/lib/plugins/methods/date';
+import { isValidDate, isDateInFuture, isDateInPast } from '@stormid/validate/src/lib/plugins/methods/date';
 
 const [ validator ] = validate('.my-form');
 validator.addMethod(
   'date', //name of custom validation group
   isValidDate, // date validation method imported from the library 
   'Enter a valid date', // error message
+  [ document.getElementById('dateDay'), document.getElementById('dateMonth'), document.getElementById('dateYear') ] //date fields array [day, month, year]
+);
+
+validator.addMethod(
+  'date', //name of custom validation group
+  isDateInFuture, // date validation method imported from the library 
+  'Enter a date in the future', // error message
+  [ document.getElementById('dateDay'), document.getElementById('dateMonth'), document.getElementById('dateYear') ] //date fields array [day, month, year]
+);
+
+validator.addMethod(
+  'date', //name of custom validation group
+  isDateInPast, // date validation method imported from the library 
+  'Enter a date in the past', // error message
   [ document.getElementById('dateDay'), document.getElementById('dateMonth'), document.getElementById('dateYear') ] //date fields array [day, month, year]
 );
 </code></pre>

--- a/docs/validate.html
+++ b/docs/validate.html
@@ -279,8 +279,8 @@ const [ validator ] = validate(elements);
 <li><a href="#plugins">Plugins</a>
 <ul>
 <li><a href="#isvaliddate">isValidDate</a></li>
-<li><a href="#isDateInFuture">isDateInFuture</a></li>
-<li><a href="#isDateInPast">isDateInPast</a></li>
+<li><a href="#isFuture">isFuture</a></li>
+<li><a href="#isPast">isPast</a></li>
 </ul>
 </li>
 <li><a href="#tests">Tests</a></li>
@@ -520,9 +520,9 @@ validator.removeGroup('new-fields');
 <h3 id="isvaliddate">isValidDate</h3>
 <p>Validate three separate day/month/year fields (similar to the govuk design system date component) as a single valid date.</p>
 <p>The minimum accepted year value in the isValidDate plugin is 1000. To set a different (more recent) minimum value consider using the <a href="#min">min</a> validator on the year input.</p>
-<h3 id="isDateInFuture">isDateInFuture</h3>
+<h3 id="isFuture">isFuture</h3>
 <p>Validate three separate day/month/year fields (similar to the govuk design system date component) as a single date in the future.</p>
-<h3 id="isDateInPast">isDateInPast</h3>
+<h3 id="isPast">isPast</h3>
 <p>Validate three separate day/month/year fields (similar to the govuk design system date component) as a single date in the past. (Today's date is valid)</p>
 <p>HTML</p>
 <pre><code>&lt;fieldset&gt;
@@ -542,7 +542,7 @@ validator.removeGroup('new-fields');
 </code></pre>
 <p>JS</p>
 <pre><code>import validate from '@stormid/validate';
-import { isValidDate, isDateInFuture, isDateInPast } from '@stormid/validate/src/lib/plugins/methods/date';
+import { isValidDate, isFuture, isPast } from '@stormid/validate/src/lib/plugins/methods/date';
 
 const [ validator ] = validate('.my-form');
 validator.addMethod(
@@ -554,14 +554,14 @@ validator.addMethod(
 
 validator.addMethod(
   'date', //name of custom validation group
-  isDateInFuture, // date validation method imported from the library 
+  isFuture, // date validation method imported from the library 
   'Enter a date in the future', // error message
   [ document.getElementById('dateDay'), document.getElementById('dateMonth'), document.getElementById('dateYear') ] //date fields array [day, month, year]
 );
 
 validator.addMethod(
   'date', //name of custom validation group
-  isDateInPast, // date validation method imported from the library 
+  isPast, // date validation method imported from the library 
   'Enter a date in the past', // error message
   [ document.getElementById('dateDay'), document.getElementById('dateMonth'), document.getElementById('dateYear') ] //date fields array [day, month, year]
 );

--- a/packages/validate/README.md
+++ b/packages/validate/README.md
@@ -87,8 +87,8 @@ Multiple validators can be used on a single field. Custom validators can be adde
     - [removeGroup](#removegroup)
   - [Plugins](#plugins)
     - [isValidDate](#isvaliddate)
-    - [isDateInFuture](#isDateInFuture)
-    - [isDateInPast](#isDateInPast)
+    - [isFuture](#isfuture)
+    - [isPast](#ispast)
   - [Tests](#tests)
   - [License](#license)
 
@@ -434,11 +434,11 @@ Validate three separate day/month/year fields (similar to the govuk design syste
 
 The minimum accepted year value in the isValidDate plugin is 1000. To set a different (more recent) minimum value consider using the [min](#min) validator on the year input. 
 
-### isDateInFuture
+### isFuture
 Validate three separate day/month/year fields (similar to the govuk design system date component) as a single date in the future.
 
-### isDateInPast
-Validate three separate day/month/year fields (similar to the govuk design system date component) as a single date in the past.  (Today's date is valid)
+### isPast
+Validate three separate day/month/year fields (similar to the govuk design system date component) as a single date in the past- today's date is valid.
 
 HTML
 ```

--- a/packages/validate/README.md
+++ b/packages/validate/README.md
@@ -87,6 +87,8 @@ Multiple validators can be used on a single field. Custom validators can be adde
     - [removeGroup](#removegroup)
   - [Plugins](#plugins)
     - [isValidDate](#isvaliddate)
+    - [isDateInFuture](#isDateInFuture)
+    - [isDateInPast](#isDateInPast)
   - [Tests](#tests)
   - [License](#license)
 
@@ -431,6 +433,12 @@ Plugins are a set of pre-built custom validators that are included in the packag
 Validate three separate day/month/year fields (similar to the govuk design system date component) as a single valid date.
 
 The minimum accepted year value in the isValidDate plugin is 1000. To set a different (more recent) minimum value consider using the [min](#min) validator on the year input. 
+
+### isDateInFuture
+Validate three separate day/month/year fields (similar to the govuk design system date component) as a single date in the future.
+
+### isDateInPast
+Validate three separate day/month/year fields (similar to the govuk design system date component) as a single date in the past.  (Today's date is valid)
 
 HTML
 ```

--- a/packages/validate/__tests__/integration/plugins/date.js
+++ b/packages/validate/__tests__/integration/plugins/date.js
@@ -1,7 +1,7 @@
 import validate from '../../../src';
-import { isValidDate } from '../../../src/lib/plugins/methods/date';
+import { isValidDate, isDateInFuture, isDateInPast } from '../../../src/lib/plugins/methods/date';
 
-describe('Validate > Integration > Plugins > Date', () => {
+describe('Validate > Integration > Plugins > Valid Date', () => {
 
     it('should add a validation method to a group', async () => {
         expect.assertions(2);
@@ -190,5 +190,372 @@ describe('Validate > Integration > Plugins > Date', () => {
         const validityState = await validator.validate();
         expect(validityState).toEqual(true);
     });
+
+
+});
+
+describe('Validate > Integration > Plugins > Date in future', () => {
+
+    it('should add a validation method to a group', async () => {
+        expect.assertions(2);
+        document.body.innerHTML = `<form class="form">
+            <fieldset>
+                <legend>
+                    <span>Date</span>
+                    <span data-valmsg-for="date" id="date-error-message"></span>
+                    <span data-valmsg-for="dateDay" id="date-Day-error-message"></span>
+                    <span data-valmsg-for="dateMonth" id="date-Month-error-message"></span>
+                    <span data-valmsg-for="dateYear" id="date-Year-error-message"></span>
+                </legend>
+                <div class="flex">
+                    <input id="dateDay" name="dateDay" inputmode="numeric" data-val="true" data-val-required="Enter a day" aria-required="true"/>
+                    <input id="dateMonth" name="dateMonth" inputmode="numeric" data-val="true" data-val-required="Enter a month" aria-required="true"/>
+                    <input id="dateYear" name="dateYear" inputmode="numeric" data-val="true" data-val-required="Enter a year" aria-required="true" />
+                </div>
+            </fieldset>
+        </form>`;
+        
+        const dateErrorNode = document.querySelector('#date-error-message');
+        const dayInput = document.querySelector('#dateDay');
+        const dayErrorNode = document.querySelector('#date-Day-error-message');
+        const monthInput = document.querySelector('#dateMonth');
+        const monthErrorNode = document.querySelector('#date-Month-error-message');
+        const yearInput = document.querySelector('#dateYear');
+        const yearErrorNode = document.querySelector('#date-Year-error-message');
+        const [ validator ] = validate('form');
+
+        expect(validator.getState().groups).toEqual({
+            dateDay: {
+                serverErrorNode: dayErrorNode,
+                validators: [{ type: 'required', message: 'Enter a day' }],
+                fields: [dayInput],
+                valid: false
+            },
+            dateMonth: {
+                serverErrorNode: monthErrorNode,
+                validators: [{ type: 'required', message: 'Enter a month'  }],
+                fields: [monthInput],
+                valid: false
+            },
+            dateYear: {
+                serverErrorNode: yearErrorNode,
+                validators: [{ type: 'required', message: 'Enter a year'  }],
+                fields: [yearInput],
+                valid: false
+            }
+        });
+        const dateFields = [ dayInput, monthInput, yearInput ];
+        const message = 'Enter a date in the future';
+        validator.addMethod('date', isDateInFuture, message, dateFields);
+
+        expect(validator.getState().groups).toEqual({
+            dateDay: {
+                serverErrorNode: dayErrorNode,
+                validators: [{ type: 'required', message: 'Enter a day' }],
+                fields: [dayInput],
+                valid: false
+            },
+            dateMonth: {
+                serverErrorNode: monthErrorNode,
+                validators: [{ type: 'required', message: 'Enter a month'  }],
+                fields: [monthInput],
+                valid: false
+            },
+            dateYear: {
+                serverErrorNode: yearErrorNode,
+                validators: [{ type: 'required', message: 'Enter a year'  }],
+                fields: [yearInput],
+                valid: false
+            },
+            date: {
+                serverErrorNode: dateErrorNode,
+                validators: [{ type: 'custom', method: isDateInFuture, message }],
+                fields: dateFields,
+                valid: false
+            }
+        });
+    });
+
+    it('should return false for a date in the past', async () => {
+        document.body.innerHTML = `<form class="form">
+            <fieldset>
+                <legend>
+                    <span>Date</span>
+                    <span data-valmsg-for="date" id="date-error-message"></span>
+                    <span data-valmsg-for="dateDay" id="date-Day-error-message"></span>
+                    <span data-valmsg-for="dateMonth" id="date-Month-error-message"></span>
+                    <span data-valmsg-for="dateYear" id="date-Year-error-message"></span>
+                </legend>
+                <div class="flex">
+                    <input id="dateDay" name="dateDay" inputmode="numeric" data-val="true" value="01" />
+                    <input id="dateMonth" name="dateMonth" inputmode="numeric" data-val="true" value="02" />
+                    <input id="dateYear" name="dateYear" inputmode="numeric" data-val="true" value="2000" />
+                </div>
+            </fieldset>
+        </form>`;
+        
+        const dateErrorNode = document.querySelector('#date-error-message');
+        const dayInput = document.querySelector('#dateDay');
+        const monthInput = document.querySelector('#dateMonth');
+        const yearInput = document.querySelector('#dateYear');
+        const [ validator ] = validate('form');
+
+        const dateFields = [ dayInput, monthInput, yearInput ];
+        const message = 'Enter a date in the future';
+        validator.addMethod('date', isDateInFuture, message, dateFields);
+
+        const validityState = await validator.validate();
+        expect(validityState).toEqual(false);
+        expect(dateErrorNode.textContent).toEqual(message);
+    });
+
+    it('should return true for a date in the future', async () => {
+        const currentDateYear = new Date().getFullYear();
+
+        document.body.innerHTML = `<form class="form">
+            <fieldset>
+                <legend>
+                    <span>Date</span>
+                    <span data-valmsg-for="date" id="date-error-message"></span>
+                    <span data-valmsg-for="dateDay" id="date-Day-error-message"></span>
+                    <span data-valmsg-for="dateMonth" id="date-Month-error-message"></span>
+                    <span data-valmsg-for="dateYear" id="date-Year-error-message"></span>
+                </legend>
+                <div class="flex">
+                    <input id="dateDay" name="dateDay" inputmode="numeric" data-val="true" value="28" />
+                    <input id="dateMonth" name="dateMonth" inputmode="numeric" data-val="true" value="02" />
+                    <input id="dateYear" name="dateYear" inputmode="numeric" data-val="true" value="${currentDateYear+1}" />
+                </div>
+            </fieldset>
+        </form>`;
+        
+        const dayInput = document.querySelector('#dateDay');
+        const monthInput = document.querySelector('#dateMonth');
+        const yearInput = document.querySelector('#dateYear');
+        const [ validator ] = validate('form');
+
+        const dateFields = [ dayInput, monthInput, yearInput ];
+        const message = 'Enter a date in the future';
+        validator.addMethod('date', isDateInFuture, message, dateFields);
+        const validityState = await validator.validate();
+        expect(validityState).toEqual(true);
+    });
+
+    it('should return false for todays date', async () => {
+        const currentDateYear = new Date().getFullYear();
+        const currentDateMonth = new Date().getMonth() + 1;
+        const currentDateDay = new Date().getDate();
+
+        document.body.innerHTML = `<form class="form">
+            <fieldset>
+                <legend>
+                    <span>Date</span>
+                    <span data-valmsg-for="date" id="date-error-message"></span>
+                    <span data-valmsg-for="dateDay" id="date-Day-error-message"></span>
+                    <span data-valmsg-for="dateMonth" id="date-Month-error-message"></span>
+                    <span data-valmsg-for="dateYear" id="date-Year-error-message"></span>
+                </legend>
+                <div class="flex">
+                    <input id="dateDay" name="dateDay" inputmode="numeric" data-val="true" value="${currentDateDay}" />
+                    <input id="dateMonth" name="dateMonth" inputmode="numeric" data-val="true" value="${currentDateMonth}" />
+                    <input id="dateYear" name="dateYear" inputmode="numeric" data-val="true" value="${currentDateYear}" />
+                </div>
+            </fieldset>
+        </form>`;
+        
+        const dayInput = document.querySelector('#dateDay');
+        const monthInput = document.querySelector('#dateMonth');
+        const yearInput = document.querySelector('#dateYear');
+        const [ validator ] = validate('form');
+
+        const dateFields = [ dayInput, monthInput, yearInput ];
+        const message = 'Enter a date in the future';
+        validator.addMethod('date', isDateInFuture, message, dateFields);
+        const validityState = await validator.validate();
+        expect(validityState).toEqual(false);
+    });
+
+});
+
+describe('Validate > Integration > Plugins > Date in Past', () => {
+
+    it('should add a validation method to a group', async () => {
+        expect.assertions(2);
+        document.body.innerHTML = `<form class="form">
+            <fieldset>
+                <legend>
+                    <span>Date</span>
+                    <span data-valmsg-for="date" id="date-error-message"></span>
+                    <span data-valmsg-for="dateDay" id="date-Day-error-message"></span>
+                    <span data-valmsg-for="dateMonth" id="date-Month-error-message"></span>
+                    <span data-valmsg-for="dateYear" id="date-Year-error-message"></span>
+                </legend>
+                <div class="flex">
+                    <input id="dateDay" name="dateDay" inputmode="numeric" data-val="true" data-val-required="Enter a day" aria-required="true"/>
+                    <input id="dateMonth" name="dateMonth" inputmode="numeric" data-val="true" data-val-required="Enter a month" aria-required="true"/>
+                    <input id="dateYear" name="dateYear" inputmode="numeric" data-val="true" data-val-required="Enter a year" aria-required="true" />
+                </div>
+            </fieldset>
+        </form>`;
+        
+        const dateErrorNode = document.querySelector('#date-error-message');
+        const dayInput = document.querySelector('#dateDay');
+        const dayErrorNode = document.querySelector('#date-Day-error-message');
+        const monthInput = document.querySelector('#dateMonth');
+        const monthErrorNode = document.querySelector('#date-Month-error-message');
+        const yearInput = document.querySelector('#dateYear');
+        const yearErrorNode = document.querySelector('#date-Year-error-message');
+        const [ validator ] = validate('form');
+
+        expect(validator.getState().groups).toEqual({
+            dateDay: {
+                serverErrorNode: dayErrorNode,
+                validators: [{ type: 'required', message: 'Enter a day' }],
+                fields: [dayInput],
+                valid: false
+            },
+            dateMonth: {
+                serverErrorNode: monthErrorNode,
+                validators: [{ type: 'required', message: 'Enter a month'  }],
+                fields: [monthInput],
+                valid: false
+            },
+            dateYear: {
+                serverErrorNode: yearErrorNode,
+                validators: [{ type: 'required', message: 'Enter a year'  }],
+                fields: [yearInput],
+                valid: false
+            }
+        });
+        const dateFields = [ dayInput, monthInput, yearInput ];
+        const message = 'Enter a date in the past';
+        validator.addMethod('date', isDateInPast, message, dateFields);
+
+        expect(validator.getState().groups).toEqual({
+            dateDay: {
+                serverErrorNode: dayErrorNode,
+                validators: [{ type: 'required', message: 'Enter a day' }],
+                fields: [dayInput],
+                valid: false
+            },
+            dateMonth: {
+                serverErrorNode: monthErrorNode,
+                validators: [{ type: 'required', message: 'Enter a month'  }],
+                fields: [monthInput],
+                valid: false
+            },
+            dateYear: {
+                serverErrorNode: yearErrorNode,
+                validators: [{ type: 'required', message: 'Enter a year'  }],
+                fields: [yearInput],
+                valid: false
+            },
+            date: {
+                serverErrorNode: dateErrorNode,
+                validators: [{ type: 'custom', method: isDateInPast, message }],
+                fields: dateFields,
+                valid: false
+            }
+        });
+    });
+
+    it('should return false for a date in the future', async () => {
+        const currentDateYear = new Date().getFullYear();
+        document.body.innerHTML = `<form class="form">
+            <fieldset>
+                <legend>
+                    <span>Date</span>
+                    <span data-valmsg-for="date" id="date-error-message"></span>
+                    <span data-valmsg-for="dateDay" id="date-Day-error-message"></span>
+                    <span data-valmsg-for="dateMonth" id="date-Month-error-message"></span>
+                    <span data-valmsg-for="dateYear" id="date-Year-error-message"></span>
+                </legend>
+                <div class="flex">
+                    <input id="dateDay" name="dateDay" inputmode="numeric" data-val="true" value="01" />
+                    <input id="dateMonth" name="dateMonth" inputmode="numeric" data-val="true" value="02" />
+                    <input id="dateYear" name="dateYear" inputmode="numeric" data-val="true" value="${currentDateYear+1}" />
+                </div>
+            </fieldset>
+        </form>`;
+        
+        const dateErrorNode = document.querySelector('#date-error-message');
+        const dayInput = document.querySelector('#dateDay');
+        const monthInput = document.querySelector('#dateMonth');
+        const yearInput = document.querySelector('#dateYear');
+        const [ validator ] = validate('form');
+
+        const dateFields = [ dayInput, monthInput, yearInput ];
+        const message = 'Enter a date in the past';
+        validator.addMethod('date', isDateInPast, message, dateFields);
+
+        const validityState = await validator.validate();
+        expect(validityState).toEqual(false);
+        expect(dateErrorNode.textContent).toEqual(message);
+    });
+
+    it('should return true for a date in the past', async () => {
+        document.body.innerHTML = `<form class="form">
+            <fieldset>
+                <legend>
+                    <span>Date</span>
+                    <span data-valmsg-for="date" id="date-error-message"></span>
+                    <span data-valmsg-for="dateDay" id="date-Day-error-message"></span>
+                    <span data-valmsg-for="dateMonth" id="date-Month-error-message"></span>
+                    <span data-valmsg-for="dateYear" id="date-Year-error-message"></span>
+                </legend>
+                <div class="flex">
+                    <input id="dateDay" name="dateDay" inputmode="numeric" data-val="true" value="28" />
+                    <input id="dateMonth" name="dateMonth" inputmode="numeric" data-val="true" value="02" />
+                    <input id="dateYear" name="dateYear" inputmode="numeric" data-val="true" value="2000" />
+                </div>
+            </fieldset>
+        </form>`;
+        
+        const dayInput = document.querySelector('#dateDay');
+        const monthInput = document.querySelector('#dateMonth');
+        const yearInput = document.querySelector('#dateYear');
+        const [ validator ] = validate('form');
+
+        const dateFields = [ dayInput, monthInput, yearInput ];
+        const message = 'Enter a date in the past';
+        validator.addMethod('date', isDateInPast, message, dateFields);
+        const validityState = await validator.validate();
+        expect(validityState).toEqual(true);
+    });
+
+    it('should return true for todays date', async () => {
+        const currentDateYear = new Date().getFullYear();
+        const currentDateMonth = new Date().getMonth() + 1;
+        const currentDateDay = new Date().getDate();
+
+        document.body.innerHTML = `<form class="form">
+            <fieldset>
+                <legend>
+                    <span>Date</span>
+                    <span data-valmsg-for="date" id="date-error-message"></span>
+                    <span data-valmsg-for="dateDay" id="date-Day-error-message"></span>
+                    <span data-valmsg-for="dateMonth" id="date-Month-error-message"></span>
+                    <span data-valmsg-for="dateYear" id="date-Year-error-message"></span>
+                </legend>
+                <div class="flex">
+                    <input id="dateDay" name="dateDay" inputmode="numeric" data-val="true" value="${currentDateDay}" />
+                    <input id="dateMonth" name="dateMonth" inputmode="numeric" data-val="true" value="${currentDateMonth}" />
+                    <input id="dateYear" name="dateYear" inputmode="numeric" data-val="true" value="${currentDateYear}" />
+                </div>
+            </fieldset>
+        </form>`;
+        
+        const dayInput = document.querySelector('#dateDay');
+        const monthInput = document.querySelector('#dateMonth');
+        const yearInput = document.querySelector('#dateYear');
+        const [ validator ] = validate('form');
+
+        const dateFields = [ dayInput, monthInput, yearInput ];
+        const message = 'Enter a date in the past';
+        validator.addMethod('date', isDateInPast, message, dateFields);
+        const validityState = await validator.validate();
+        expect(validityState).toEqual(true);
+    });
+
 
 });

--- a/packages/validate/__tests__/integration/plugins/date.js
+++ b/packages/validate/__tests__/integration/plugins/date.js
@@ -1,5 +1,5 @@
 import validate from '../../../src';
-import { isValidDate, isDateInFuture, isDateInPast } from '../../../src/lib/plugins/methods/date';
+import { isValidDate, isFuture, isPast } from '../../../src/lib/plugins/methods/date';
 
 describe('Validate > Integration > Plugins > Valid Date', () => {
 
@@ -246,7 +246,7 @@ describe('Validate > Integration > Plugins > Date in future', () => {
         });
         const dateFields = [ dayInput, monthInput, yearInput ];
         const message = 'Enter a date in the future';
-        validator.addMethod('date', isDateInFuture, message, dateFields);
+        validator.addMethod('date', isFuture, message, dateFields);
 
         expect(validator.getState().groups).toEqual({
             dateDay: {
@@ -269,7 +269,7 @@ describe('Validate > Integration > Plugins > Date in future', () => {
             },
             date: {
                 serverErrorNode: dateErrorNode,
-                validators: [{ type: 'custom', method: isDateInFuture, message }],
+                validators: [{ type: 'custom', method: isFuture, message }],
                 fields: dateFields,
                 valid: false
             }
@@ -302,7 +302,7 @@ describe('Validate > Integration > Plugins > Date in future', () => {
 
         const dateFields = [ dayInput, monthInput, yearInput ];
         const message = 'Enter a date in the future';
-        validator.addMethod('date', isDateInFuture, message, dateFields);
+        validator.addMethod('date', isFuture, message, dateFields);
 
         const validityState = await validator.validate();
         expect(validityState).toEqual(false);
@@ -336,7 +336,7 @@ describe('Validate > Integration > Plugins > Date in future', () => {
 
         const dateFields = [ dayInput, monthInput, yearInput ];
         const message = 'Enter a date in the future';
-        validator.addMethod('date', isDateInFuture, message, dateFields);
+        validator.addMethod('date', isFuture, message, dateFields);
         const validityState = await validator.validate();
         expect(validityState).toEqual(true);
     });
@@ -370,7 +370,7 @@ describe('Validate > Integration > Plugins > Date in future', () => {
 
         const dateFields = [ dayInput, monthInput, yearInput ];
         const message = 'Enter a date in the future';
-        validator.addMethod('date', isDateInFuture, message, dateFields);
+        validator.addMethod('date', isFuture, message, dateFields);
         const validityState = await validator.validate();
         expect(validityState).toEqual(false);
     });
@@ -429,7 +429,7 @@ describe('Validate > Integration > Plugins > Date in Past', () => {
         });
         const dateFields = [ dayInput, monthInput, yearInput ];
         const message = 'Enter a date in the past';
-        validator.addMethod('date', isDateInPast, message, dateFields);
+        validator.addMethod('date', isPast, message, dateFields);
 
         expect(validator.getState().groups).toEqual({
             dateDay: {
@@ -452,7 +452,7 @@ describe('Validate > Integration > Plugins > Date in Past', () => {
             },
             date: {
                 serverErrorNode: dateErrorNode,
-                validators: [{ type: 'custom', method: isDateInPast, message }],
+                validators: [{ type: 'custom', method: isPast, message }],
                 fields: dateFields,
                 valid: false
             }
@@ -486,7 +486,7 @@ describe('Validate > Integration > Plugins > Date in Past', () => {
 
         const dateFields = [ dayInput, monthInput, yearInput ];
         const message = 'Enter a date in the past';
-        validator.addMethod('date', isDateInPast, message, dateFields);
+        validator.addMethod('date', isPast, message, dateFields);
 
         const validityState = await validator.validate();
         expect(validityState).toEqual(false);
@@ -518,7 +518,7 @@ describe('Validate > Integration > Plugins > Date in Past', () => {
 
         const dateFields = [ dayInput, monthInput, yearInput ];
         const message = 'Enter a date in the past';
-        validator.addMethod('date', isDateInPast, message, dateFields);
+        validator.addMethod('date', isPast, message, dateFields);
         const validityState = await validator.validate();
         expect(validityState).toEqual(true);
     });
@@ -552,7 +552,7 @@ describe('Validate > Integration > Plugins > Date in Past', () => {
 
         const dateFields = [ dayInput, monthInput, yearInput ];
         const message = 'Enter a date in the past';
-        validator.addMethod('date', isDateInPast, message, dateFields);
+        validator.addMethod('date', isPast, message, dateFields);
         const validityState = await validator.validate();
         expect(validityState).toEqual(true);
     });

--- a/packages/validate/example/src/js/index.js
+++ b/packages/validate/example/src/js/index.js
@@ -1,5 +1,5 @@
 import validate from '../../../src';
-import { isValidDate, isDateInFuture, isDateInPast } from '../../../src/lib/plugins/methods/date';
+import { isValidDate, isFuture, isPast } from '../../../src/lib/plugins/methods/date';
 
 {
     const [ validator ] = validate('form');
@@ -13,7 +13,7 @@ import { isValidDate, isDateInFuture, isDateInPast } from '../../../src/lib/plug
 
     validator.addMethod(
         'date', //name of custom validation group
-        isDateInFuture, // date validation method imported from the library 
+        isFuture, // date validation method imported from the library 
         'Enter a valid date in the future', // error message
         [ document.getElementById('dateDay'), document.getElementById('dateMonth'), document.getElementById('dateYear') ] //date fields array [day, month, year]
     );

--- a/packages/validate/example/src/js/index.js
+++ b/packages/validate/example/src/js/index.js
@@ -1,5 +1,5 @@
 import validate from '../../../src';
-import { isValidDate } from '../../../src/lib/plugins/methods/date';
+import { isValidDate, isDateInFuture, isDateInPast } from '../../../src/lib/plugins/methods/date';
 
 {
     const [ validator ] = validate('form');
@@ -8,6 +8,13 @@ import { isValidDate } from '../../../src/lib/plugins/methods/date';
         'date', //name of custom validation group
         isValidDate, // date validation method imported from the library 
         'Enter a valid date', // error message
+        [ document.getElementById('dateDay'), document.getElementById('dateMonth'), document.getElementById('dateYear') ] //date fields array [day, month, year]
+    );
+
+    validator.addMethod(
+        'date', //name of custom validation group
+        isDateInFuture, // date validation method imported from the library 
+        'Enter a valid date in the future', // error message
         [ document.getElementById('dateDay'), document.getElementById('dateMonth'), document.getElementById('dateYear') ] //date fields array [day, month, year]
     );
 

--- a/packages/validate/src/lib/plugins/methods/date.js
+++ b/packages/validate/src/lib/plugins/methods/date.js
@@ -29,15 +29,15 @@ export const isValidDate = (value, fields) => {
 };
 
 //A function to make sure dates are in the future
-export const isDateInFuture = (value, fields) => {
+export const isFuture = (value, fields) => {
     const inputDate = new Date(fields[2].value, fields[1].value - 1, fields[0].value).getTime();
     const currentDate = new Date().getTime();
     return inputDate > currentDate;
-}
+};
 
 //A function to make sure dates are in the past
-export const isDateInPast = (value, fields) => {
+export const isPast = (value, fields) => {
     const inputDate = new Date(fields[2].value, fields[1].value - 1, fields[0].value).getTime();
     const currentDate = new Date().getTime();
     return inputDate < currentDate;
-}
+};

--- a/packages/validate/src/lib/plugins/methods/date.js
+++ b/packages/validate/src/lib/plugins/methods/date.js
@@ -27,3 +27,17 @@ export const isValidDate = (value, fields) => {
 
     return true;
 };
+
+//A function to make sure dates are in the future
+export const isDateInFuture = (value, fields) => {
+    const inputDate = new Date(fields[2].value, fields[1].value - 1, fields[0].value).getTime();
+    const currentDate = new Date().getTime();
+    return inputDate > currentDate;
+}
+
+//A function to make sure dates are in the past
+export const isDateInPast = (value, fields) => {
+    const inputDate = new Date(fields[2].value, fields[1].value - 1, fields[0].value).getTime();
+    const currentDate = new Date().getTime();
+    return inputDate < currentDate;
+}


### PR DESCRIPTION
Addresses issue/enhancement #236 

Also added date in Past.  For dates in the past, Today's date also counts as valid.  This has been allowed in the use cases or acceptance criteria I've seen for this one (DoB) as technically the DoB could be today?  Happy to adjust based on opinion there though!

Also, I've only ever used this in addition to a separate check that a date is valid in the first place.  I guess there would be an argument that for it to be turned into a useful plugin, it should also run the valid date check first, even if that's not explicitly added as a validation method.  What do you think?