### PR TITLE
Adding tab trapping to cookie banner

### DIFF
--- a/docs/validate.html
+++ b/docs/validate.html
@@ -279,8 +279,8 @@ const [ validator ] = validate(elements);
 <li><a href="#plugins">Plugins</a>
 <ul>
 <li><a href="#isvaliddate">isValidDate</a></li>
-<li><a href="#isfuture">isFutureDate</a></li>
-<li><a href="#ispast">isPastDate</a></li>
+<li><a href="#isfuturedate">isFutureDate</a></li>
+<li><a href="#ispastdate">isPastDate</a></li>
 </ul>
 </li>
 <li><a href="#tests">Tests</a></li>
@@ -520,9 +520,9 @@ validator.removeGroup('new-fields');
 <h3 id="isvaliddate">isValidDate</h3>
 <p>Validate three separate day/month/year fields (similar to the govuk design system date component) as a single valid date.</p>
 <p>The minimum accepted year value in the isValidDate plugin is 1000. To set a different (more recent) minimum value consider using the <a href="#min">min</a> validator on the year input.</p>
-<h3 id="isfuture">isFutureDate</h3>
+<h3 id="isfuturedate">isFutureDate</h3>
 <p>Validate three separate day/month/year fields (similar to the govuk design system date component) as a single date in the future.</p>
-<h3 id="ispast">isPastDate</h3>
+<h3 id="ispastdate">isPastDate</h3>
 <p>Validate three separate day/month/year fields (similar to the govuk design system date component) as a single date in the past- today’s date is valid.</p>
 <p>HTML</p>
 <pre><code>&lt;fieldset&gt;

--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -99,7 +99,9 @@ const cookieBanner = banner({
         formMessage: 'privacy-banner__form-msg',
         formAnnouncement: 'privacy-banner__form-announcement', //screen reader announcement
         title: 'privacy-banner__form-title',
-        description: 'privacy-banner__form-description'
+        description: 'privacy-banner__form-description',
+        bannerToggle: 'on--privacy-banner-toggle', //the class that's applied to the body tag when an inner toggles is open (if used)
+        bannerToggleTrigger: 'js-toggle-btn' //the class of the button which opens the inner toggle (if used)
     },
     hideBannerOnFormPage: false, //don't show the banner when the user is on the same page as a consent form
     savedMessage: 'Your settings have been saved.', //displayed after consent form update,

--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -102,7 +102,9 @@ const cookieBanner = banner({
         description: 'privacy-banner__form-description'
     },
     hideBannerOnFormPage: false, //don't show the banner when the user is on the same page as a consent form
-    savedMessage: 'Your settings have been saved.', //displayed after consent form update 
+    savedMessage: 'Your settings have been saved.', //displayed after consent form update,
+    trapTab: false, //trap the user's keyboard tab within the banner when open
+    usesToggle: false, //some banner designs may use a javascript toggle to display options inside the banner.  Set this to true if in use to allow tab trapping to move inside the toggle.
     bannerTemplate(model){
         return `<section role="dialog" aria-live="polite" aria-label="Your privacy" class="${model.classNames.banner}">
             <div class="privacy-content">

--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -106,7 +106,6 @@ const cookieBanner = banner({
     hideBannerOnFormPage: false, //don't show the banner when the user is on the same page as a consent form
     savedMessage: 'Your settings have been saved.', //displayed after consent form update,
     trapTab: false, //trap the user's keyboard tab within the banner when open
-    usesToggle: false, //some banner designs may use a javascript toggle to display options inside the banner.  Set this to true if in use to allow tab trapping to move inside the toggle.
     bannerTemplate(model){
         return `<section role="dialog" aria-live="polite" aria-label="Your privacy" class="${model.classNames.banner}">
             <div class="privacy-content">

--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -99,9 +99,7 @@ const cookieBanner = banner({
         formMessage: 'privacy-banner__form-msg',
         formAnnouncement: 'privacy-banner__form-announcement', //screen reader announcement
         title: 'privacy-banner__form-title',
-        description: 'privacy-banner__form-description',
-        bannerToggle: 'on--privacy-banner-toggle', //the class that's applied to the body tag when an inner toggles is open (if used)
-        bannerToggleTrigger: 'js-toggle-btn' //the class of the button which opens the inner toggle (if used)
+        description: 'privacy-banner__form-description'
     },
     hideBannerOnFormPage: false, //don't show the banner when the user is on the same page as a consent form
     savedMessage: 'Your settings have been saved.', //displayed after consent form update,

--- a/packages/cookie-banner/example/src/index.html
+++ b/packages/cookie-banner/example/src/index.html
@@ -81,11 +81,21 @@
             clip: rect(0 0 0 0);
             border: 0;
         }
+        .privacy-banner__panel {
+            display:none;
+        }
+        .on--preferences .privacy-banner__panel {
+            display:block;
+        }
+        .on--preferences .privacy-banner__summary,
+        .on--preferences .privacy-banner__actions {
+            display: none;
+        }
     </style>
   </head>
   <body>
         <div class="embed"><div class="embed__placeholder" data-iframe-src="https://www.youtube.com/embed/qpLKTUQev30" data-iframe-title="test video"><p>Update your cookie preferences to view this content.</p><button type="button" class="embed__placeholder-btn js-preferences-update">Update preferences</button></div></div>
-      <button class="js-open-banner">Open banner</button>
+      <button class="js-preferences-update">Open banner</button>
         <div class="container">
             <div class="privacy-banner__update"></div>
             <div class="">

--- a/packages/cookie-banner/example/src/js/index.js
+++ b/packages/cookie-banner/example/src/js/index.js
@@ -1,4 +1,5 @@
 import cookieBanner from '../../../src/index';
+import toggle from '../../../../toggle/src/index';
 
 const writeCookie = state => {
     document.cookie = [
@@ -11,70 +12,146 @@ const writeCookie = state => {
     ].join('');
 };
     
-window.addEventListener('DOMContentLoaded', () => {
-    window.__pb__ = cookieBanner({
-        tid: 'UA-401849-33',
-        secure: false,
-        hideBannerOnFormPage: false,
-        necessary: [
-            () => {
-                writeCookie({
-                    settings: {
-                        name: '.Test.NecessaryCookie',
-                        expiry: 3
-                    },
-                    consent: '666',
-                });
-            }
-        ],
-        types: {
-            performance: {
-                suggested: 1,
-                title: 'Performance preferences',
-                description: 'Performance cookies are used to measure the performance of our website and make improvements. Your personal data is not identified.',
-                labels: {
-                    yes: 'Pages you visit and actions you take will be measured and used to improve the service',
-                    no: 'Pages you visit and actions you take will not be measured and used to improve the service'
+const config = {
+    name: '.Components.Dev.Consent',
+    tid: 'UA-401849-33',
+    secure: false,
+    hideBannerOnFormPage: false,
+    trapTab: true,
+    necessary: [
+        () => {
+            writeCookie({
+                settings: {
+                    name: '.Test.NecessaryCookie',
+                    expiry: 3
                 },
-                fns: [
-                    () => {
-                        // console.log('Performance fn');
-                        writeCookie({
-                            settings: {
-                                name: '.Test.PerformanceCookie',
-                                expiry: 3
-                            },
-                            consent: '666',
-                        });
-                    },
-                    state => state.utils.renderIframe(),
-                    state => state.utils.gtmSnippet('12345666')
-                ]
-            },
-            ads: {
-                title: 'Set your personalised ads preferences',
-                description: 'We work with advertising partners to show you ads for our products and services across the web.  You can choose whether we collect and share that data with our partners below. ',
-                labels: {
-                    yes: 'Our partners might serve you ads knowing you have visited our website',
-                    no: 'Our partners will still serve you ads, but they will not know you have visited out website'
-                },
-                fns: [
-                    () => {
-                        // console.log('Ads fn');
-                        writeCookie({
-                            settings: {
-                                name: '.Test.AdsCookie',
-                                expiry: 3
-                            },
-                            consent: '666',
-                        });
-                    }
-                ]
-            }
+                consent: '666',
+            });
         }
-    });
+    ],
+    types: {
+        performance: {
+            suggested: 1,
+            title: 'Performance preferences',
+            description: 'Performance cookies are used to measure the performance of our website and make improvements. Your personal data is not identified.',
+            labels: {
+                yes: 'Pages you visit and actions you take will be measured and used to improve the service',
+                no: 'Pages you visit and actions you take will not be measured and used to improve the service'
+            },
+            fns: [
+                () => {
+                    // console.log('Performance fn');
+                    writeCookie({
+                        settings: {
+                            name: '.Test.PerformanceCookie',
+                            expiry: 3
+                        },
+                        consent: '666',
+                    });
+                },
+                state => state.utils.renderIframe(),
+                state => state.utils.gtmSnippet('12345666')
+            ]
+        },
+        ads: {
+            title: 'Set your personalised ads preferences',
+            description: 'We work with advertising partners to show you ads for our products and services across the web.  You can choose whether we collect and share that data with our partners below. ',
+            labels: {
+                yes: 'Our partners might serve you ads knowing you have visited our website',
+                no: 'Our partners will still serve you ads, but they will not know you have visited out website'
+            },
+            fns: [
+                () => {
+                    // console.log('Ads fn');
+                    writeCookie({
+                        settings: {
+                            name: '.Test.AdsCookie',
+                            expiry: 3
+                        },
+                        consent: '666',
+                    });
+                }
+            ]
+        }
+    },
+    bannerTemplate(model){
+        return `<section role="dialog" aria-live="polite" aria-label="Cookies" class="${model.classNames.banner}">
+            <div class="privacy-content">
+                <div class="wrap">
+                    <div class="col xs-12 privacy-banner__inner">
+                        <!--googleoff: all-->
+                        <div class="privacy-banner__content">
+                            <div class="privacy-banner__title">Cookies</div>
+                            <p class="privacy-banner__summary">This web service uses cookies to ensure it functions correctly, and to help gather analytics data which is used to help us improve the service.</p>
+                            <p class="privacy-banner__summary">Find out more from our <a class="privacy-banner__link" rel="noopener noreferrer nofollow" href="/privacy">privacy policy</a> and <a class="privacy-banner__link" rel="noopener noreferrer nofollow" href="${model.policyURL}">cookie policy</a>.</p>
+                        </div>
+                        <div class="privacy-banner__actions">
+                            <button type="button" class="privacy-banner__btn ${model.classNames.acceptBtn}">Accept and close</button>
+                            <button type="button" class="privacy-banner__link js-toggle__preferences ${model.classNames.optionsBtn}">Your options</button>
+                        </div>
+                        <div id="preferences" class="privacy-banner__panel js-toggle-banner" data-toggle="js-toggle__preferences">
+                            <p><button type="button" class="privacy-banner__btn-text ${model.classNames.acceptBtn}">Accept and close </button> or edit your choices below and click 'Save my choices'.</p>
+                            <div class="privacy-banner__form-container"></div>
+                        </div>
+                        <!--googleon: all-->
+                    </div>
+                </div>
+            </div>
+        </section>`;
+    },
+    formTemplate(model){
+        return `<form id="preferences-form" class="row ${model.settings.classNames.form}" novalidate>
+                ${Object.keys(model.settings.types).map(type => `<div class="privacy-banner__col col"><fieldset class="${model.settings.classNames.fieldset}">
+                <legend class="${model.settings.classNames.legend}">
+                    <span class="${model.settings.classNames.title}">${model.settings.types[type].title}</span>
+                    <span class="${model.settings.classNames.description}">${model.settings.types[type].description}</span>
+                </legend>
+                <div class="privacy-banner__row">
+                    <div class="relative">
+                        <label class="privacy-banner__label">
+                            <input
+                                class="${model.settings.classNames.field}"
+                                type="radio"
+                                name="privacy-${type.split(' ')[0].replace(' ', '-')}"
+                                value="1"
+                                ${model.consent[type] === 1 ? ` checked` : ''}>
+                            <span class="privacy-banner__label-text">Ok</span>
+                            <span class="privacy-banner__label-description">${model.settings.types[type].labels.yes}</span>
+                        </label>    
+                    </div>
+                </div>
+                <div class="privacy-banner__row">
+                    <div class="relative">
+                        <label class="privacy-banner__label">
+                            <input
+                                class="${model.settings.classNames.field}"
+                                type="radio"
+                                name="privacy-${type.split(' ')[0].replace(' ', '-')}"
+                                value="0"
+                                ${model.consent[type] === 0 ? ` checked` : ''}>
+                            <span class="privacy-banner__label-text">No</span>
+                            <span class="privacy-banner__label-description">${model.settings.types[type].labels.no}</span>
+                        </label>
+                    </div>
+                </div>
+            </fieldset></div>`).join('')}
+            <div class="privacy-banner__set col">
+                <button class="${model.settings.classNames.submitBtn}"${Object.keys(model.consent).length !== Object.keys(model.settings.types).length ? ` disabled` : ''}>Save my choices</button>
+                <div class="privacy-banner__set-accept">Or <button type="button" class="privacy-banner__btn-text ${model.settings.classNames.acceptBtn}">Accept and close</button></div>
+            </div>
+        </form>`;
+    }
+};
 
-    document.querySelector('.js-open-banner').addEventListener('click', e => {
-        window.__pb__.showBanner();
-    });
+window.addEventListener('DOMContentLoaded', () => {
+    let bannerToggle;
+    document.addEventListener('banner.show', () => [ bannerToggle ] = toggle('.js-toggle-banner'));
+    document.addEventListener('banner.hide', () => bannerToggle.getState().isOpen && bannerToggle.startToggle());
+
+    const banner = cookieBanner(config);
+
+    [].slice.call(document.querySelectorAll('.js-preferences-update')).forEach(btn => btn.addEventListener('click', e => {
+        banner.showBanner();
+        bannerToggle.startToggle();
+    }));
 });

--- a/packages/cookie-banner/src/lib/constants.js
+++ b/packages/cookie-banner/src/lib/constants.js
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 export const ACCEPTED_TRIGGERS = ['button', 'a'];
 
-export const FOCUSABLE_ELEMENTS = ['a[href]', 'area[href]', 'input:not([disabled])', 'select:not([disabled])', 'textarea:not([disabled])', 'button:not([disabled])', 'iframe', 'object', 'embed', '[contenteditable]', '[tabindex]:not([tabindex="-1"])'];
+export const FOCUSABLE_ELEMENTS = ['a[href]', 'area[href]', 'input:not([disabled]):not([type=hidden])', 'select:not([disabled])', 'textarea:not([disabled])', 'button:not([disabled])', 'iframe', 'object', 'embed', '[contenteditable]', '[tabindex]:not([tabindex="-1"])'];
 
 export const HOSTNAME = 'https://www.google-analytics.com';
 

--- a/packages/cookie-banner/src/lib/defaults.js
+++ b/packages/cookie-banner/src/lib/defaults.js
@@ -24,9 +24,13 @@ export default {
         formMessage: 'privacy-banner__form-msg',
         formAnnouncement: 'privacy-banner__form-announcement',
         title: 'privacy-banner__form-title',
-        description: 'privacy-banner__form-description'
+        description: 'privacy-banner__form-description',
+        bannerToggle: 'on--privacy-banner-toggle',
+        bannerToggleTrigger: 'js-toggle-btn'
     },
     hideBannerOnFormPage: true,
+    trapTab: false,
+    usesToggle: false,
     savedMessage: 'Your settings have been saved.',
     bannerTemplate(model){
         return `<section role="dialog" aria-live="polite" aria-label="Your privacy" class="${model.classNames.banner}">

--- a/packages/cookie-banner/src/lib/defaults.js
+++ b/packages/cookie-banner/src/lib/defaults.js
@@ -30,7 +30,6 @@ export default {
     },
     hideBannerOnFormPage: true,
     trapTab: false,
-    usesToggle: false,
     savedMessage: 'Your settings have been saved.',
     bannerTemplate(model){
         return `<section role="dialog" aria-live="polite" aria-label="Your privacy" class="${model.classNames.banner}">

--- a/packages/cookie-banner/src/lib/factory.js
+++ b/packages/cookie-banner/src/lib/factory.js
@@ -1,4 +1,4 @@
-import { cookiesEnabled, extractFromCookie, noop, renderIframe, gtmSnippet} from './utils';
+import { cookiesEnabled, extractFromCookie, noop, renderIframe, gtmSnippet } from './utils';
 import { showBanner, initBanner, initForm, initBannerListeners, keyListener } from './ui';
 import { necessary, apply } from './consent';
 import { createStore } from './store';

--- a/packages/cookie-banner/src/lib/factory.js
+++ b/packages/cookie-banner/src/lib/factory.js
@@ -1,5 +1,5 @@
-import { cookiesEnabled, extractFromCookie, noop, renderIframe, gtmSnippet } from './utils';
-import { showBanner, initBanner, initForm, initBannerListeners } from './ui';
+import { cookiesEnabled, extractFromCookie, noop, renderIframe, gtmSnippet} from './utils';
+import { showBanner, initBanner, initForm, initBannerListeners, keyListener } from './ui';
 import { necessary, apply } from './consent';
 import { createStore } from './store';
 import { initialState } from './reducers';
@@ -22,6 +22,7 @@ export default settings => {
         {
             settings,
             bannerOpen: false,
+            keyListener: keyListener(Store),
             persistentMeasurementParams: settings.tid ? composeParams(cid, settings.tid) : false,
             consent,
             utils: { renderIframe, gtmSnippet }

--- a/packages/cookie-banner/src/lib/reducers.js
+++ b/packages/cookie-banner/src/lib/reducers.js
@@ -4,6 +4,10 @@ export const updateBannerOpen = (state, data) => Object.assign({}, state, {
     bannerOpen: data
 });;
 
+export const updateBanner = (state, data) => Object.assign({}, state, {
+    banner: data
+});;
+
 export const updateConsent = (state, data) => Object.assign({}, state, {
     consent: Object.assign({}, state.consent, data)
 });

--- a/packages/cookie-banner/src/lib/ui.js
+++ b/packages/cookie-banner/src/lib/ui.js
@@ -35,7 +35,7 @@ export const initBannerListeners = Store => () => {
     const acceptBtns = [].slice.call(document.querySelectorAll(composeSelector(state.settings.classNames.acceptBtn)));
     const optionsBtn = document.querySelector(composeSelector(state.settings.classNames.optionsBtn));
 
-    if(state.settings.trapTab) document.addEventListener('keydown', state.keyListener);
+    if (state.settings.trapTab) document.addEventListener('keydown', state.keyListener);
 
     acceptBtns.forEach(acceptBtn => {
         if (acceptBtns) {
@@ -86,7 +86,7 @@ const trapTab = state => event => {
     if (event.shiftKey && focusedIndex === 0) {
         event.preventDefault();
         focusableChildren[focusableChildren.length - 1].focus();
-    } else if ((!event.shiftKey && focusedIndex === focusableChildren.length - 1) || (state.settings.usesToggle && (!document.body.classList.contains(state.settings.classNames.bannerToggle) && (document.activeElement.classList.contains(state.settings.classNames.bannerToggleTrigger))))) {
+    } else if (!event.shiftKey && focusedIndex === focusableChildren.length - 1) {
         event.preventDefault();
         focusableChildren[0].focus();
     }
@@ -96,15 +96,14 @@ export const keyListener = Store => event => {
     if (Store.getState().banner && event.keyCode === 9) trapTab(Store.getState())(event);
 };
 
-const removeBanner = (Store) => () => {
+const removeBanner = Store => () => {
     const state = Store.getState();
     const banner = state.banner;
     if (banner && banner.parentNode) {
         banner.parentNode.removeChild(banner);
         Store.update(updateBannerOpen, false, [ broadcast(EVENTS.HIDE, Store) ]);
     }
-    form.removeEventListener('change', enableButton);
-    if(state.settings.trapTab) document.removeEventListener('keydown', state.keyListener);
+    if (state.settings.trapTab) document.removeEventListener('keydown', state.keyListener);
 };
 
 const suggestedConsent = state => Object.keys(state.consent).length > 0
@@ -128,7 +127,6 @@ export const initForm = (Store, track = true) => () => {
     if (state.settings.tid && track) measure(state, MEASUREMENTS.FORM_DISPLAY);
 
     const form = document.querySelector(`.${state.settings.classNames.form}`);
-    const banner = state.banner;
     const button = document.querySelector(`.${state.settings.classNames.submitBtn}`);
     const groups = [].slice.call(document.querySelectorAll(`.${state.settings.classNames.field}`)).reduce((groups, field) => {
         const groupName = field.getAttribute('name').replace('privacy-', '');

--- a/packages/cookie-banner/src/lib/ui.js
+++ b/packages/cookie-banner/src/lib/ui.js
@@ -1,7 +1,7 @@
 import { writeCookie, groupValueReducer, deleteCookies, getFocusableChildren, broadcast } from './utils';
 import { ACCEPTED_TRIGGERS, MEASUREMENTS, EVENTS } from './constants';
 import { apply } from './consent';
-import { updateConsent, updateBannerOpen } from './reducers';
+import { updateConsent, updateBannerOpen, updateBanner } from './reducers';
 import { measure, composeMeasurementConsent } from './measurement';
 
 export const initBanner = Store => () => {
@@ -11,6 +11,7 @@ export const initBanner = Store => () => {
     //track banner display
     if (state.settings.tid) measure(state, MEASUREMENTS.BANNER_DISPLAY);
     
+    Store.update(updateBanner, document.querySelector(`.${state.settings.classNames.banner}`));
     Store.update(updateBannerOpen, true, [ broadcast(EVENTS.SHOW, Store) ]);
 };
 
@@ -26,13 +27,15 @@ export const showBanner = Store => cb => {
 
 export const initBannerListeners = Store => () => {
     const state = Store.getState();
-    const banner = document.querySelector(`.${state.settings.classNames.banner}`);
+    const banner = state.banner;
     if (!banner) return;
 
     const composeSelector = classSelector => ACCEPTED_TRIGGERS.map(sel => `${sel}.${classSelector}`).join(', ');
 
     const acceptBtns = [].slice.call(document.querySelectorAll(composeSelector(state.settings.classNames.acceptBtn)));
     const optionsBtn = document.querySelector(composeSelector(state.settings.classNames.optionsBtn));
+
+    if(state.settings.trapTab) document.addEventListener('keydown', state.keyListener);
 
     acceptBtns.forEach(acceptBtn => {
         if (acceptBtns) {
@@ -46,7 +49,7 @@ export const initBannerListeners = Store => () => {
                     [
                         writeCookie,
                         apply(Store),
-                        removeBanner(Store, banner),
+                        removeBanner(Store),
                         initForm(Store, false),
                         broadcast(EVENTS.CONSENT, Store),
                         //track banner accept click
@@ -75,11 +78,33 @@ export const initBannerListeners = Store => () => {
     }
 };
 
-const removeBanner = (Store, banner) => () => {
+
+const trapTab = state => event => {
+    const focusableChildren = getFocusableChildren(state.banner);
+    const focusedIndex = focusableChildren.indexOf(document.activeElement);
+
+    if (event.shiftKey && focusedIndex === 0) {
+        event.preventDefault();
+        focusableChildren[focusableChildren.length - 1].focus();
+    } else if ((!event.shiftKey && focusedIndex === focusableChildren.length - 1) || (state.settings.usesToggle && (!document.body.classList.contains(state.settings.classNames.bannerToggle) && (document.activeElement.classList.contains(state.settings.classNames.bannerToggleTrigger))))) {
+        event.preventDefault();
+        focusableChildren[0].focus();
+    }
+};
+
+export const keyListener = Store => event => {
+    if (Store.getState().banner && event.keyCode === 9) trapTab(Store.getState())(event);
+};
+
+const removeBanner = (Store) => () => {
+    const state = Store.getState();
+    const banner = state.banner;
     if (banner && banner.parentNode) {
         banner.parentNode.removeChild(banner);
         Store.update(updateBannerOpen, false, [ broadcast(EVENTS.HIDE, Store) ]);
     }
+    form.removeEventListener('change', enableButton);
+    if(state.settings.trapTab) document.removeEventListener('keydown', state.keyListener);
 };
 
 const suggestedConsent = state => Object.keys(state.consent).length > 0
@@ -103,7 +128,7 @@ export const initForm = (Store, track = true) => () => {
     if (state.settings.tid && track) measure(state, MEASUREMENTS.FORM_DISPLAY);
 
     const form = document.querySelector(`.${state.settings.classNames.form}`);
-    const banner = document.querySelector(`.${state.settings.classNames.banner}`);
+    const banner = state.banner;
     const button = document.querySelector(`.${state.settings.classNames.submitBtn}`);
     const groups = [].slice.call(document.querySelectorAll(`.${state.settings.classNames.field}`)).reduce((groups, field) => {
         const groupName = field.getAttribute('name').replace('privacy-', '');
@@ -137,7 +162,7 @@ export const initForm = (Store, track = true) => () => {
                 deleteCookies,
                 writeCookie,
                 apply(Store),
-                removeBanner(Store, banner),
+                removeBanner(Store),
                 broadcast(EVENTS.CONSENT, Store),
                 renderMessage(button),
                 renderAnnouncement(formAnnouncement),

--- a/packages/cookie-banner/src/lib/utils.js
+++ b/packages/cookie-banner/src/lib/utils.js
@@ -113,7 +113,7 @@ export const uuidv4 = () => 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]
     return v.toString(16);
 });
 
-export const getFocusableChildren = node => [].slice.call(node.querySelectorAll(FOCUSABLE_ELEMENTS.join(',')));
+export const getFocusableChildren = node => [].slice.call(node.querySelectorAll(FOCUSABLE_ELEMENTS.join(','))).filter(el => el.offsetWidth > 0 || el.offsetHeight > 0);
 
 export const broadcast = (type, Store) => () => {
     const event = new CustomEvent(type, {


### PR DESCRIPTION
Adds tab trapping to the current cookie banner implementation:

- Sets an option in the settings, defaults to false.
- The trapping needs to know whether or not the banner is using a toggle so that it can also tab into the toggled options.  I've added this as a setting with the class names in the classnames list, but I'm not sure that this is the best way to handle this... so any suggestions are super welcome
- Moved the banner DOM element into the state because it was in use in quite a few places
- I haven't added tests since we can't emulate the keyboard?

Absolutely would be good to compare to the implementation that @Nick-StormID and roll with the best of both worlds!