### PR TITLE
Show next/previous buttons if there is more than one item (not 2)

### DIFF
--- a/packages/modal-gallery/src/lib/dom.js
+++ b/packages/modal-gallery/src/lib/dom.js
@@ -49,7 +49,7 @@ const loadImages = Store => i => {
 export const initUI = Store => state => {
     const { settings, items, keyListener } = Store.getState();
     const container = document.body.appendChild(settings.templates.overlay());
-    const buttons = items.length > 2 ? settings.templates.buttons() : '';
+    const buttons = items.length > 1 ? settings.templates.buttons() : '';
     container.insertAdjacentHTML('beforeend', settings.templates.overlayInner(buttons, items.map(settings.templates.details).map(settings.templates.item(items)).join('')));
     const domItems = [].slice.call(container.querySelectorAll('.js-modal-gallery__item'));
     const domTotals = container.querySelector('.js-gallery-totals');


### PR DESCRIPTION
I noticed today that in a gallery with two items the next/previous buttons don't show.  I think these should be appended when there is more than one item - but at the moment the code is checking that there is more than two.