### PR TITLE
remove auto height setting

### DIFF
--- a/packages/textarea/src/index.js
+++ b/packages/textarea/src/index.js
@@ -4,7 +4,10 @@ import { getSelection } from './lib/utils';
 const isHidden = el => el.offsetParent === null;
 
 const update = ({ target }) => {
-    target.style.height = `${target.scrollHeight}px`;
+    const scrollCache = window.scrollY;
+	target.style.height = 'auto';
+	target.style.height = `${target.scrollHeight}px`;
+	window.scrollTo(0, scrollCache);
 };
 const initObserver = el => {
     const observer = new MutationObserver(mutationsList => {

--- a/packages/textarea/src/index.js
+++ b/packages/textarea/src/index.js
@@ -4,7 +4,6 @@ import { getSelection } from './lib/utils';
 const isHidden = el => el.offsetParent === null;
 
 const update = ({ target }) => {
-    target.style.height = 'auto';
     target.style.height = `${target.scrollHeight}px`;
 };
 const initObserver = el => {


### PR DESCRIPTION
Closes #240 

I was able to replicate this one in the examples, and the culprit seems to be setting the height of the text area to auto - causing the browser to jump.

I gave this a shot without setting the height to auto first, and it seemed to still work fine.  I checked in Chrome, FF, Edge and safari iOS.

I can see that setting the height to auto first is recommended in the blog posts I've found about auto-resizing text areas.  However those all seem to be a good few years old now, so perhaps more modern browsers no longer have that requirement in order to grab an accurate scroll height?

The original fix in the ticket also works though, so if it's better to go with that then I can update!