### PR TITLE
Adding data layer tracking for cookie banner GCMv2

### DIFF
--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -23,7 +23,8 @@ For example, to map the ad_storage, ad_user_data, and ad_personalisation to an '
 euConsentTypes: {
     ad_storage: 'test',
     ad_user_data: 'test',
-    ad_personalization: 'test'
+    ad_personalization: 'test',
+    analytics_storage: 'test'
 }
 ```
 

--- a/packages/cookie-banner/__tests__/analytics/index.js
+++ b/packages/cookie-banner/__tests__/analytics/index.js
@@ -1,0 +1,59 @@
+import cookieBanner from '../../src';
+import defaults from '../../src/lib/defaults';
+let instance;
+
+const init = () => {
+    // Set up our document body
+    document.body.innerHTML = `<div class="privacy-banner__form-container"></div>`;
+    instance = cookieBanner({
+        secure: false,
+        hideBannerOnFormPage: false,
+        types: {
+            test: {
+                title: 'Test title',
+                description: 'Test description',
+                labels: {
+                    yes: 'Pages you visit and actions you take will be measured and used to improve the service',
+                    no: 'Pages you visit and actions you take will not be measured and used to improve the service'
+                },
+                fns: [
+                    () => { }
+                ]
+            },
+            performance: {
+                title: 'Performance preferences',
+                description: 'Performance cookies are used to measure the performance of our website and make improvements. Your personal data is not identified.',
+                labels: {
+                    yes: 'Pages you visit and actions you take will be measured and used to improve the service',
+                    no: 'Pages you visit and actions you take will not be measured and used to improve the service'
+                },
+                fns: [
+                    () => { }
+                ]
+            }
+        }
+    });
+};
+
+describe(`Cookie banner > Analytics > Data layer additions`, () => {
+    beforeAll(init);
+
+    it('It should add to the dataLayer when the banner is shown', async () => {
+        expect(dataLayer.find(e => e.event === "stormcb_display")).toBeDefined();
+    });
+
+    it('It should add to the datalayer when accept all is clicked', async () => {
+        document.querySelector(`.${defaults.classNames.acceptBtn}`).click();
+        expect(dataLayer.find(e => e.event === "stormcb_accept_all")).toBeDefined();
+        expect(dataLayer.find(e => e.stormcb_performance === 1)).toBeDefined();
+        expect(dataLayer.find(e => e.stormcb_test === 1)).toBeDefined();
+    });
+
+    it('It should add to the datalayer when reject all is clicked', async () => {
+        instance.showBanner();
+        document.querySelector(`.${defaults.classNames.rejectBtn}`).click();
+        expect(dataLayer.find(e => e.event === "stormcb_reject_all")).toBeDefined();
+        expect(dataLayer.find(e => e.stormcb_performance === 0)).toBeDefined();
+        expect(dataLayer.find(e => e.stormcb_test === 0)).toBeDefined();
+    });
+});

--- a/packages/cookie-banner/__tests__/banner/showBanner.js
+++ b/packages/cookie-banner/__tests__/banner/showBanner.js
@@ -35,7 +35,6 @@ const init = () => {
     });
 };
 
-
 describe(`Cookie banner > showBanner > show banner`, () => {
     beforeAll(init);
 

--- a/packages/cookie-banner/__tests__/google-eu-consent/no-eu-consent-config.js
+++ b/packages/cookie-banner/__tests__/google-eu-consent/no-eu-consent-config.js
@@ -37,10 +37,9 @@ const init = () => {
 describe(`Cookie banner > cookies > Google EU consent > no EU consent settings`, () => {
     beforeAll(init);
 
-    it('No errors or pushes to dataLayer if no consent options configured', async () => {
+    it('No errors if no consent options configured', async () => {
         const banner = document.querySelector(`.${defaults.classNames.banner}`);
         expect(banner).not.toBeNull();
-        expect(window.dataLayer).toBeUndefined();
     });
 
 });


### PR DESCRIPTION
Requested by analytics team for cookie banner.  **This is assuming that the performance container is always loaded and only read via GTM.** as per the latest google consent spec.  

_In the olden days, as my son would say, we used to track interactions with the cookie banner into Universal Analytics. There may still be some legacy code in the banner that was for that purpose. We never updated this to GA4 for a number of reasons, but mostly because it used the measurement API. If I recall, Mick looked into it, but I don't remember us ever really using it in GA4._

__However, using Google Consent Mode v2 offers an opportunity to track slightly differently and I'm wondering how much might be involved to send dataLayer events with the following:_

- Banner displays (just an event, no other data)
- User clicks "accept all", with two variables for performance and third party both set to 1.
- User clicks "essential cookies only" with two variables for performance and third party both set to 0.
- User saves consent on cookies policy page, with two variables set to 1 or 0 depending on their choice._

_only compatible with GCMv2, but it would otherwise be throwing into the dataLayer only so not a big problem_

Cookie banner displays - to send AFTER performance container is loaded, only if the banner is displayed to the user
  // Push the banner display event to the data layer
  dataLayer.push({
    'event': 'stormcb_display'
   });
  
----------------------
Accept all button click - to send when a user clicks "Accept All" button
  // Push the accept all event to the data layer
  dataLayer.push({
    'event': 'stormcb_accept_all',
    'stormcb_performance': 1,
    'stormcb_thirdparty': 1
   });
    
----------------------
Reject all button click - to send when a user clicks "Reject All" (or equivalent) button
  // Push the reject all to the data layer
  dataLayer.push({
    'event': 'stormcb_reject_all',
    'stormcb_performance': 0,
    'stormcb_thirdparty': 0
   });
      
----------------------
Save preferences button click - to send when a user clicks "Save" (or equivalent) after editing their cookie settings
  // Push the save event to the data layer
  dataLayer.push({
    'event': 'stormcb_save',
    'stormcb_performance': 0,  // 1 if accepted, 0 if rejected
    'stormcb_thirdparty': 0    // 1 if accepted, 0 if rejected
   });