### PR TITLE
Fixes console error when initialised with no hash

### DIFF
--- a/packages/scroll-spy/__tests__/index.js
+++ b/packages/scroll-spy/__tests__/index.js
@@ -33,7 +33,7 @@ const init = () => {
             </section>
             <section id="section4" style="height:500px">
                 Section 4
-            </section>`;
+            </section></div>`;
 
     basic = scrollSpy('.js-scroll-spy');
     withCallback = scrollSpy('.js-scroll-spy-two', {

--- a/packages/scroll-spy/example/src/index.html
+++ b/packages/scroll-spy/example/src/index.html
@@ -78,6 +78,7 @@
             <a class="js-scroll-spy" href="#section1">Section 1</a>
             <a class="js-scroll-spy" href="#section2">Section 2</a>
             <a class="js-scroll-spy" href="#section3">Section 3</a>
+            <a class="js-scroll-spy" href="no-hash">No hash</a>
         </nav>
     </header>
     <div class="container">
@@ -85,7 +86,7 @@
         <h2>Example</h2>
         <p>Scroll down to see the menu to highlight the current section and to see example code.</p>
         <section id="section1">
-			Section 1
+            Section 1
         </section>
         <section id="section2" style="height:1500px">
             Section 2
@@ -93,5 +94,6 @@
         <section id="section3" style="height:500px">
             Section 3
         </section>
+    </div>
 </body>
 </html>

--- a/packages/scroll-spy/src/lib/dom.js
+++ b/packages/scroll-spy/src/lib/dom.js
@@ -10,17 +10,19 @@ export const findSpies = nodes => nodes.map(node => {
 
 export const setActive = spy => state => {
     const { settings } = state;
-    spy.node.classList.add(settings.activeClassName);
+    if (spy !== undefined) spy.node.classList.add(settings.activeClassName);
 };
 
 export const unsetActive = spy => state => {
     const { settings } = state;
-    spy.node.classList.remove(settings.activeClassName);
+    if (spy !== undefined) spy.node.classList.remove(settings.activeClassName);
 };
 
 export const unsetAllActive = state => {
     const { settings, spies } = state;
-    spies.map(spy => spy.node.classList.remove(settings.activeClassName));
+    spies.map(spy => {
+        if (spy !== undefined) spy.node.classList.remove(settings.activeClassName)
+    });
 };
 
 export const findActive = state => {


### PR DESCRIPTION
When I was setting up Playwright I used the code from the Jest test in the example.html to make sure it had all the scenarios needed for testing.

The JEST markup had an example where the link didn't have a hash to test how this was handled in the initialisation.  When this example was tried in the browser and the browser scrolled - it threw a console error.  This PR is an intermediate one to address that before carrying on with the tests.